### PR TITLE
Fix markup in link to calendar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ CircuitPython Weekly Meeting Notes
 
 Each week, members of the CircuitPython community meet on `the Adafruit Discord <http://adafru.it/discord>`_ to discuss all things CircuitPython. The meetings are recorded and made `available on YouTube <https://www.youtube.com/playlist?list=PLjF7R1fz_OOUvw7tMv45xjWp0ht8yNgg0>`_ with links to notes in this repo. These notes include time codes to specific sections of the video so that one can only listen to portions of interest.
 
-The weekly happens normally at 2pm ET/11am PT on Mondays. Check the #circuitpython channel for notices of change in time and links to past episodes.  You can also subscribe to the meeting calendar `meeting.ical <`https://raw.githubusercontent.com/adafruit/{{ full_repo_name }}/master/meeting.ical>`_.
+The weekly happens normally at 2pm ET/11am PT on Mondays. Check the #circuitpython channel for notices of change in time and links to past episodes.  You can also subscribe to the meeting calendar `meeting.ical <https://raw.githubusercontent.com/adafruit/{{ full_repo_name }}/master/meeting.ical>`_.
 
 Contributing
 ============


### PR DESCRIPTION
This makes the link appear when viewing the README on github.com though the replacement of `{{ full_repo_name }}` is not occurring which means this link (as well as the code of conduct link) is still broken.  What's the right way?