### PR TITLE
Fix the calendar links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ CircuitPython Weekly Meeting Notes
 
 Each week, members of the CircuitPython community meet on `the Adafruit Discord <http://adafru.it/discord>`_ to discuss all things CircuitPython. The meetings are recorded and made `available on YouTube <https://www.youtube.com/playlist?list=PLjF7R1fz_OOUvw7tMv45xjWp0ht8yNgg0>`_ with links to notes in this repo. These notes include time codes to specific sections of the video so that one can only listen to portions of interest.
 
-The weekly happens normally at 2pm ET/11am PT on Mondays. Check the #circuitpython-dev channel for notices of change in time and links to past episodes.  You can also subscribe to the meeting calendar `meeting.ical <https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical>`_. or `view it in your web browser <https://open-web-calendar.herokuapp.com/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmaster%2Fmeeting.ical&title=CircuitPython%20Weekly%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda>`_
+The weekly happens normally at 2pm ET/11am PT on Mondays. Check the #circuitpython-dev channel for notices of change in time and links to past episodes.  You can also subscribe to the meeting calendar `meeting.ical <https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/main/meeting.ical>`_. or `view it in your web browser <https://open-web-calendar.herokuapp.com/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda>`_
 
 Contributing
 ============


### PR DESCRIPTION
These links were incorrectly using the wrong branch name, instead of "main".