### PR TITLE
Add CircuitPython Weekly Meeting notes for Feb 2, 2026

### DIFF
--- a/2026/2026-02-02.md
+++ b/2026/2026-02-02.md
@@ -1,0 +1,216 @@
+# CircuitPython Weekly Meeting for February 2, 2026
+
+Video is available [on YouTube](https://youtu.be/3b7ZhhTR6NY).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## Community News
+
+### Compiler Explorer Now Supports MicroPython
+
+Thanks to Anson Mansfield’s work, Compiler Explorer now supports MicroPython. It provides a tool to compile code and quickly see the disassembly, all from the comfort of a browser window \- [Compiler Explorer](https://godbolt.org/). Via [MicroPython Meetup Notes](https://melbournemicropythonmeetup.github.io/January-2026-Meetup/).
+
+### Kimi Code, an Open Source Python-Based Coding Agent
+
+Kimi Code is an open-source coding agent under an Apache 2.0 License. It's Python-based and integrates with VS Code, Cursor, etc. It can also be connected to MoltBot (formerly ClawdBot). Costs apparently are [lower than Claude Opus](https://x.com/grok/status/2016812504068796606) \- [kimi.com](https://www.kimi.com/), and [Kimi Code CLI GitHub](https://github.com/MoonshotAI/kimi-cli), [Connect to MoltBot](https://x.com/KimiProduct/status/2016791330022973892). Via [X](https://x.com/Kimi_Moonshot/status/2016034259350520226).
+
+### Particle is Being Acquired by Digi
+
+Wireless microcontroller board maker Particle is being acquired by Digi, home of the venerable XBee platform that started affordable wireless on microcontrollers \- [Particle.io](https://www.particle.io/blog/particle-is-being-acquired-by-digi-to-power-the-next-40-years-of-iot-innovation/). Via the [Adafruit Blog](https://blog.adafruit.com/2026/01/27/particle-is-being-acquired-by-digi/).
+
+### PyCharm IDE for Python Development Just Got a Big Update
+
+JetBrains dropped a major update for its Python IDE, PyCharm 2025.3.2. PyCharm and Google Colab are normally treated like separate tools, with the former PyCharm for that serious, heavy-duty local IDE power, and Colab for easy, GPU-accelerated cloud access. This update merges them \- [Yahoo Tech](https://tech.yahoo.com/computing/articles/pycharm-ide-python-development-just-182149426.html) and [JetBrains Blog](https://blog.jetbrains.com/pycharm/2026/01/google-colab-support-is-now-available-in-pycharm-2025-3-2/?utm_source=syndication). [Download](https://www.jetbrains.com/pycharm/download/?utm_source=syndication&section=windows).
+
+### Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### Overall
+
+* 13 pull requests merged  
+  * 11 authors \- FoamyGuy, dhalbert, hartzell, mamirov, ru-wallace, tekktrik, zeetwii, GuLinux, mikeysklar, Copilot, fearnoeval  
+  * 7 reviewers \- TheKitty, FoamyGuy, dhalbert, caternuson, tannewt, makermelissa, tekktrik  
+* 3 closed issues by 2 people, 7 opened by 7 people
+
+### Core
+
+* 3 pull requests merged  
+  * 3 authors \- hartzell, fearnoeval, dhalbert  
+  * 2 reviewers \- tannewt, dhalbert  
+* 29 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9349](https://github.com/adafruit/circuitpython/pull/9349) (Open 593 days)  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 527 days)  
+  * [https://github.com/adafruit/circuitpython/pull/9844](https://github.com/adafruit/circuitpython/pull/9844) (Open 430 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/9909](https://github.com/adafruit/circuitpython/pull/9909) (Open 405 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 364 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 285 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10303](https://github.com/adafruit/circuitpython/pull/10303) (Open 276 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 269 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 223 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10474](https://github.com/adafruit/circuitpython/pull/10474) (Open 205 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 197 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 191 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10540](https://github.com/adafruit/circuitpython/pull/10540) (Open 184 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 184 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10571](https://github.com/adafruit/circuitpython/pull/10571) (Open 167 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 151 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10646](https://github.com/adafruit/circuitpython/pull/10646) (Open 126 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 109 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10674](https://github.com/adafruit/circuitpython/pull/10674) (Open 108 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10755](https://github.com/adafruit/circuitpython/pull/10755) (Open 48 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10757](https://github.com/adafruit/circuitpython/pull/10757) (Open 47 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10778](https://github.com/adafruit/circuitpython/pull/10778) (Open 13 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10783](https://github.com/adafruit/circuitpython/pull/10783) (Open 9 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 5 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10795](https://github.com/adafruit/circuitpython/pull/10795) (Open 2 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10794](https://github.com/adafruit/circuitpython/pull/10794) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10793](https://github.com/adafruit/circuitpython/pull/10793) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 1 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10797](https://github.com/adafruit/circuitpython/pull/10797) (Open 0 days)  
+* 2 closed issues by 1 people, 6 opened by 6 people  
+* 855 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.0.x: 14 open issues  
+* 10.1.0: 9 open issues  
+* 10.x.x: 89 open issues  
+* 11.0.0: 10 open issues  
+* Libraries: 16 open issues  
+* Long term: 672 open issues  
+* Support: 24 open issues  
+* Third-party: 19 open issues  
+* 2 issues not assigned a milestone
+
+### Libraries
+
+* Adafruit Libraries: 380 Community Libraries: 172 (Total: 552\)  
+* 6 pull requests merged  
+  * 6 authors \- FoamyGuy, dhalbert, Copilot, **ru-wallace**, tekktrik, **zeetwii**  
+  * 4 reviewers \- TheKitty, FoamyGuy, dhalbert, tekktrik  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_TSC2007/pull/9](https://github.com/adafruit/Adafruit_CircuitPython_TSC2007/pull/9) (Days open: 14\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_BMP5xx/pull/4](https://github.com/adafruit/Adafruit_CircuitPython_BMP5xx/pull/4) (Days open: 7\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_TSL2591/pull/34](https://github.com/adafruit/Adafruit_CircuitPython_TSL2591/pull/34) (Days open: 6\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_PCA9554/pull/4](https://github.com/adafruit/Adafruit_CircuitPython_PCA9554/pull/4) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_ESP32S2TFT/pull/19](https://github.com/adafruit/Adafruit_CircuitPython_ESP32S2TFT/pull/19) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_ESP32S2TFT/pull/16](https://github.com/adafruit/Adafruit_CircuitPython_ESP32S2TFT/pull/16) (Days open: 1\)  
+  * 34 open pull requests (Oldest: 1264, Newest: 6\)  
+* 1 closed issues by 1 people, 0 opened by 0 people  
+  * 769 open issues  
+  * 1 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_ESP32S2TFT](https://github.com/adafruit/Adafruit_CircuitPython_ESP32S2TFT)  
+  * [adafruit/Adafruit\_CircuitPython\_TSL2591](https://github.com/adafruit/Adafruit_CircuitPython_TSL2591)  
+  * [EGJ-Moorington/CircuitPython\_Button\_Handler](https://github.com/EGJ-Moorington/CircuitPython_Button_Handler)  
+  * [buildwithpiper/PiperBlocklyLibrary](https://github.com/buildwithpiper/PiperBlocklyLibrary)
+
+### Blinka
+
+* 4 pull requests merged  
+  * 3 authors \- GuLinux, mikeysklar, mamirov  
+  * 2 reviewers \- caternuson, makermelissa  
+* 16 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1578 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 537 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 533 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/888](https://github.com/adafruit/Adafruit_Blinka/pull/888) (Open 520 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/908](https://github.com/adafruit/Adafruit_Blinka/pull/908) (Open 450 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 279 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/989](https://github.com/adafruit/Adafruit_Blinka/pull/989) (Open 211 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 97 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 97 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 97 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 97 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 97 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/72](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/72) (Open 24 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/71](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/71) (Open 24 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 24 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/69](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/69) (Open 24 days)  
+* 0 closed issues by 0 people, 1 opened by 1 people  
+* 146 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 166
+
+## Hug reports
+
+@tannewt (host)
+
+* @dcd for watching my deep dives and taking time codes.  
+* @foamyguy for recording the meeting for me.
+
+@danh
+
+* Recent bug reporters who have written issues: @cater, @j0j26, @jmangum, @djecken, @grgrant, @justmobilize, and quite a few more.  
+* @tekktrik for jumping back in with a bunch of PR’s.
+
+@foamyguy
+
+* @tekktrik for working on several library and infrastructure issues over the past few weeks  
+* @RetiredWizard for adding support for eSpeak to the local Spell Jam TTS backends ([https://adafruit-playground.com/u/retiredwizard/pages/your-own-tts-engine-for-the-fruit-jam-spell-jam-app](https://adafruit-playground.com/u/retiredwizard/pages/your-own-tts-engine-for-the-fruit-jam-spell-jam-app))
+
+RetiredWizard (text only)
+
+* @Foamyguy for his fun and inspiring streams covering CircuitPython, Raspberry Pi and AI topics  
+* Group Hug\!
+
+@tekktrik (not present)
+
+- @danh for taking a look at my issue in the core \- don’t often do that, much less for anything that isn’t a docstring.  
+- @2bndy5 for PRs bringing pre-commit to the CircuitPython build tools repository  
+- Group hug\!
+
+## Status Updates
+
+@tannewt (host)
+
+* Draft PR for native sim tests is failing CI but Dan approved. (So it is close.)  
+* Yoto PR is green on CI and waiting review.  
+* Need to write out guide page for Yoto reverse engineering.  
+* Main quest is using native sim to test BLE implementation.  
+* Side quests for agents:  
+  * Getting networking going with native sim for web workflow and socket tests. (Not the ethernet or wifi connection process though.)  
+  * Getting USB over IP working for USB testing.  
+  * Getting playback from a perfetto trace working for testing stuff that reads input signals: digitalio, pulseio, frequencyio, countio.
+
+@danh
+
+* Fixed build errors in AirLift WiFi PR. I posted some sample code for human testers. Looking for testers\!  
+* Looking at some of the existing 10.0.x and 10.1.0 issues to see what to work on before a release.  
+* Also will look at MicroPython merges, P4 WiFi.
+
+@foamyguy
+
+* Set up, document, and experiment with Open Claw (Clawdbot/Moltbot) on RPi5.   
+* Tried out MicroPython OS on desktop.
+
+@tekktrik (not present)
+
+- PR reviews, particularly in the build tools  
+- Picking up some quick fixes here and there  
+- Reopening some old ideas for CI/CD improvements, particularly using Wokwi to analyze the amount of memory used by libraries due to importing them \- more to share after some prototyping  
+- Hoping to continue working on my CircuitPython CoAP library as time allows
+
+## In The Weeds
+
+## Wrap-Up
+
+* Next week is on Monday. Two week’s is on Tuesday. (President’s Day in the US)


### PR DESCRIPTION
Added the meeting notes for the CircuitPython Weekly Meeting held on February 2, 2026, including community news, status updates, and reminders.