### PR TITLE
Add March 2, 2026 meeting notes

### DIFF
--- a/2026/2026-03-02.md
+++ b/2026/2026-03-02.md
@@ -1,0 +1,224 @@
+# CircuitPython Weekly Meeting for March 2, 2026
+
+Video is available [on YouTube](https://youtu.be/pmYkWzWgjxA).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 3:07 Community News
+
+### 3:21 µReticulum for MicroPython Released
+
+µReticulum is a pure MicroPython implementation of the [Reticulum](https://reticulum.network/) network stack, designed to run on microcontrollers like the ESP32 and Raspberry Pi Pico W \- [GitHub](https://github.com/varna9000/micropython-reticulum).
+
+"[Reticulum](https://reticulum.network/) is the cryptography-based networking stack for building local and wide-area networks with readily available hardware. Reticulum can continue to operate even in adverse conditions with very high latency and extremely low bandwidth. The vision of Reticulum is to allow anyone to operate their own sovereign communication networks."
+
+### 4:04 microclawup, an AI-powered ESP32 GPIO Controller Written in MicroPython
+
+OneDot6374 has created microclawup to control ESP32 GPIO with natural language via Telegram (MicroPython \+ Groq AI). You send a natural language message on Telegram, Groq AI converts it to a hardware command, and your ESP32 executes it. Inspired by zclaw (which is in C). Tested on ESP32-C3, S3, and C6 \- [Reddit](https://www.reddit.com/r/circuitpython/comments/1rds4c9/hey_everyone_i_built_microclawup_an_aipowered/) and [GitHub](https://github.com/kritishmohapatra/microclawup).
+
+Features:
+
+- Natural language GPIO control  
+- Groq AI — completely free  
+- Persistent memory across reboots  
+- WiFi auto-reconnect  
+- /status and /help commands  
+- Easy setup with Python via setup.py
+
+### 4:57 MicroPython Brings Flip-Dot Displays Into the 21st Century
+
+Maker GenerallyOkayTimes received a flip-dot display, like that used on buses: high visibility and cute. The display is driven by the SMT32 controller which speaks to an ESP8285 running MicroPython. Driving the display is a board called the Flippity210. The board is being tested out in a series of MicroPython experiments. The display successfully ran Conway’s Game of Life and a clock, though the limited RAM of the ESP8285 made heavy HTTPS requests — such as fetching public transit schedules — impractical \- [Codeberg.org](https://codeberg.org/generallyokay/pages/src/branch/main/flipdot-bad-apple-2026.md) and [hackster.io](https://www.hackster.io/news/bringing-flip-dot-displays-into-the-21st-century-4cbc186d6f35). *Ed. Maybe the project could use a decent ESP32-S3 for data retrieval?*
+
+### 5:54 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 6:32 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 6:46 Overall
+
+* 18 pull requests merged  
+  * 9 authors \- FoamyGuy, mikeysklar, weblate, samson0v, dhalbert, makermelissa, relic-se, alec-bike, tannewt  
+  * 5 reviewers \- dhalbert, FoamyGuy, makermelissa, ladyada, tannewt  
+* 6 closed issues by 5 people, 7 opened by 6 people
+
+### 7:38 Core
+
+* 12 pull requests merged  
+  * 5 authors \- FoamyGuy, dhalbert, relic-se, weblate, tannewt  
+  * 2 reviewers \- dhalbert, tannewt  
+* 23 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 555 days)  
+  * [https://github.com/adafruit/circuitpython/pull/9844](https://github.com/adafruit/circuitpython/pull/9844) (Open 458 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/9909](https://github.com/adafruit/circuitpython/pull/9909) (Open 433 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 392 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 313 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 297 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 251 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10474](https://github.com/adafruit/circuitpython/pull/10474) (Open 233 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 225 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 219 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10540](https://github.com/adafruit/circuitpython/pull/10540) (Open 212 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 212 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10571](https://github.com/adafruit/circuitpython/pull/10571) (Open 195 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 179 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10646](https://github.com/adafruit/circuitpython/pull/10646) (Open 154 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 137 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10674](https://github.com/adafruit/circuitpython/pull/10674) (Open 136 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10778](https://github.com/adafruit/circuitpython/pull/10778) (Open 41 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 33 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 29 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10844](https://github.com/adafruit/circuitpython/pull/10844) (Open 6 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 4 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10860](https://github.com/adafruit/circuitpython/pull/10860) (Open 2 days) (draft)  
+* 5 closed issues by 4 people, 5 opened by 4 people  
+* 843 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.1.x: 2 open issues  
+* 10.2.0: 1 open issues  
+* 10.x.x: 104 open issues  
+* 11.0.0: 10 open issues  
+* Libraries: 16 open issues  
+* Long term: 675 open issues  
+* Support: 20 open issues  
+* Third-party: 15 open issues  
+* 0 issues not assigned a milestone
+
+### 8:40 Libraries
+
+* Adafruit Libraries: 382 Community Libraries: 174 (Total: 556\)  
+* 5 pull requests merged  
+  * 4 authors \- FoamyGuy, **alec-bike**, **samson0v**, mikeysklar  
+  * 4 reviewers \- dhalbert, FoamyGuy, ladyada, tannewt  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/CircuitPython\_Community\_Bundle/pull/269](https://github.com/adafruit/CircuitPython_Community_Bundle/pull/269) (Days open: 8\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_ESP32SPI/pull/228](https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/228) (Days open: 6\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Logging/pull/70](https://github.com/adafruit/Adafruit_CircuitPython_Logging/pull/70) (Days open: 2\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bitmap\_Font/pull/74](https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font/pull/74) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Display\_Text/pull/236](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/pull/236) (Days open: 1\)  
+  * 42 open pull requests (Oldest: 1292, Newest: 1\)  
+* 1 closed issues by 1 people, 2 opened by 2 people  
+  * 772 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### 12:47 Library updates in the last seven days:
+
+* **New Libraries**  
+  * [thingsboard/CircuitPython\_thingsboard-client-sdk](https://github.com/thingsboard/CircuitPython_thingsboard-client-sdk)  
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_Logging](https://github.com/adafruit/Adafruit_CircuitPython_Logging)  
+  * [adafruit/Adafruit\_CircuitPython\_YotoPlayer](https://github.com/adafruit/Adafruit_CircuitPython_YotoPlayer)  
+  * [adafruit/Adafruit\_CircuitPython\_Display\_Text](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text)  
+  * [relic-se/CircuitPython\_SynthVoice](https://github.com/relic-se/CircuitPython_SynthVoice)  
+  * [tekktrik/CircuitPython\_functools](https://github.com/tekktrik/CircuitPython_functools)
+
+### 13:02 Blinka
+
+* 1 pull requests merged  
+  * 1 authors \- makermelissa  
+  * 2 reviewers \- makermelissa, tannewt  
+* 20 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1606 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 565 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 561 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/888](https://github.com/adafruit/Adafruit_Blinka/pull/888) (Open 548 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/908](https://github.com/adafruit/Adafruit_Blinka/pull/908) (Open 478 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 307 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/989](https://github.com/adafruit/Adafruit_Blinka/pull/989) (Open 239 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 125 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 125 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 125 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 125 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 125 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 52 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/69](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/69) (Open 52 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/1040](https://github.com/adafruit/Adafruit_Blinka/pull/1040) (Open 10 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Python\_PlatformDetect/pull/409](https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/409) (Open 8 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/1041](https://github.com/adafruit/Adafruit_Blinka/pull/1041) (Open 5 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/173](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/173) (Open 4 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/75](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/75) (Open 2 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/74](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/74) (Open 2 days)  
+* 0 closed issues by 0 people, 0 opened by 0 people  
+* 146 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 166
+
+## 13:41 Hug reports
+
+14:19 @tannewt (host)
+
+* Marshal (aka kamocat) for investigating async busio.
+
+14:31 @danh
+
+* @tannewt for bug fixing and strategic direction talks  
+* @keen101 and @w4iei (GitHub) for bug reports
+
+15:00 @foamyguy
+
+* Moonshine dev @evanking for a quick fix to an issue with some examples I reported on their discord  
+* @tekktrik for many fixes and improvements to libraries and infrastructure
+
+15:35 @tekktrik (not present)
+
+- @foamyguy for all the PR reviews  
+- Group hug\!
+
+## 15:44 Status Updates
+
+16:10 @tannewt (host)
+
+* Hopefully fixed a flaky Zephyr BLE test.  
+* Fixed S3 crashing on startup due to IDF 5.5.3 change where a function call crashes when not init.  
+* Host networking for Zephyr is merged in.  
+* GPIO input and rotaryio is merged in.  
+* Working on Zephyr display support. Works in sim and on a couple boards. The boards have incorrect colors. RA8 is very slow for some reason.  
+* Working on updating to latest Zephyr main to get latest bug fixes.  
+* Also working on BLE connect.  
+* Out Friday so Tim will Deep Dive in my spot.
+
+18:34 @danh
+
+* Fixing some interrelated bugs: SPI pin management, SPI locking in Espressif when doing SD card operations from USB.  
+* Claude was helpful in diagnosing a task priority problem in the USB SPI code.
+
+20:24 @foamyguy
+
+* Moonshine voice control on RPi guide published  
+* Looked into MicropythonOS and lvgl\_micropython. Added touch driver for TSC2007 and made a build of MicropythonOS for Metro S3 \+ 2.8” TFT Shield  
+* Antialiasing support merged in BitmapFont and DisplayText. PR submitted to DisplayText with example code that shows 4 levels of bit depth. Looked into lvfontio core module, antialiasing can work with that for the serial terminal but with 2 caveats: The way height is measured currently causes clipping on the bottom of some fonts, and the default font used Unifont doesn’t get rendered with actual antialiasing at size 16 (the size used currently). With larger font sizes the grey pixels do appear in the font and can be rendered by CircuitPython using a custom palette.  
+* New weekly stream starting Tuesdays 11am Eastern / 8am Pacific / 10am Central
+
+23:45 @tekktrik (not present)
+
+- Updating my community libraries with new functionality, tests, code coverage metrics  
+- Finding and preparing some fixes for some infrastructure in the bundles  
+- Still hoping to get into more CI work built on top of the Zephyr OS work in the core \- thanks for the answers/discussion from In The Weeds previously
+
+## 24:11 In The Weeds
+
+24:33 @tekktrik (not present)
+
+- PyPI releases now require changes to how licenses are defined in pyproject.toml when building libraries for distribution on PyPI:  [GitHub gist showing example](https://gist.github.com/tekktrik/0e40c91623ad3e7b9c5a6bd9d2b00446)  
+  - [Correct implementation removes Trove classifier(s) and simplifies project.license to a string](https://github.com/tekktrik/CircuitPython_Nitroclass/blob/12f56903e109d130e231532869412c99dcbc78ee/pyproject.toml#L35-L42).  
+  - I can patch the cookiecutter and also create a git/adabot patch for all the libraries but will need someone (or a token) with more elevated GitHub org permissions to help me actually run adabot.  
+  - Issue created for this in [the cookiecutter repository](https://github.com/adafruit/cookiecutter-adafruit-circuitpython/issues/254).  
+  - ~~Might be a good time to also [implement the ability to define multiple packages for the bundle building process](https://github.com/adafruit/circuitpython-build-tools/pull/147) since we’re making changes to pyproject.toml expectations.~~  Thanks @foamyguy\!
+
+## 27:04 Wrap-Up
+
+* Next week is at the normal time BUT the US starts daylight savings time next weekend. So, double check your local time if you are outside the US.


### PR DESCRIPTION
Add CircuitPython Weekly Meeting notes for March 2, 2026, including community news, state of CircuitPython, and library updates.