### PR TITLE
Add CircuitPython Weekly Meeting notes for March 9, 2026

### DIFF
--- a/2026/2026-03-09.md
+++ b/2026/2026-03-09.md
@@ -1,0 +1,211 @@
+# CircuitPython Weekly Meeting for March 9, 2026
+
+Video is available [on YouTube](https://youtu.be/pSYocIK_oT4).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 2:30 Community News
+
+### 2:39 Rovari Circuit Studio: New CircuitPython IDE
+
+Rovari Circuit Studio a free and open source CircuitPython IDE built as part of the Rovari Embedded platform project – [YouTube](https://www.youtube.com/watch?v=DKyTevXR5jg) and [Discord](https://discord.com/channels/327254708534116352/537365702651150357/1478891859458654258) (Join via [adafru.it/discord](https://discord.com/invite/5FBsBHU)).
+
+“Rovari Circuit Studio a free and open source CircuitPython IDE built as part of the Rovari Embedded platform project. It has everything you expect from Mu and more. Standard features include auto board detection, a code formatter, error line highlighting with traceback, built-in code snippets, a library manager with automatic bundling and version matching, a serial plotter with autoformat detection and safe file writes with fsync so no more silent code.py corruption on Windows. It has a safe to remove indicator so you know if it's safe to unplug the board or not…
+
+Its offline desktop application is currently in Windows but they’re making it cross platform, and they are adding support for BLE and WiFi for ESP boards. It aims to support all boards, but Rovari is centered on RISC-V so RISC-V boards are ‘first class citizens’ and CircuitPython is first class, not an afterthought….”
+
+### 4:16 The MicroPython Triage Team: Goals and Processes
+
+On the MicroPython forums, Anson Mansfield writes about the MicroPython Triage Team – Goals and Processes – [Adafruit Blog](https://blog.adafruit.com/2026/03/04/the-micropython-triage-team-goals-and-processes/) and [GitHub Thread](https://github.com/orgs/micropython/discussions/18878).
+
+“As of writing, there are 1392 open issues and 495 open PRs on micropython/micropython — including some that were opened all the way back in 2014, twelve years ago\! With the creation of the new @micropython/triage-team, I’d like to propose we break this backlog into a series of more achievable short term triage goals, and to as part of that, adopt and document some specific model workflow for triaging them.
+
+MicroPython should only adopt official goals and recommendations for Triage Team that stand firmly atop the underlying norms we mean them to explain and encourage, and the principled reasons we’d have to encourage them. But for all of the above reasons, we should adopt a set of short-term goals and an accompanying ‘model workflow’ that’s as specific and actionable as possible within that.”
+
+### 5:10 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 5:55 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 6:20 Overall
+
+* 15 pull requests merged  
+  * 7 authors \- tekktrik, tannewt, FoamyGuy, weblate, dhalbert, makermelissa, BlitzCityDIY  
+  * 4 reviewers \- FoamyGuy, tannewt, dhalbert, makermelissa  
+* 5 closed issues by 3 people, 5 opened by 5 people
+
+### 6:46 Core
+
+* 7 pull requests merged  
+  * 4 authors \- FoamyGuy, weblate, dhalbert, tannewt  
+  * 2 reviewers \- tannewt, dhalbert  
+* 25 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 562 days)  
+  * [https://github.com/adafruit/circuitpython/pull/9844](https://github.com/adafruit/circuitpython/pull/9844) (Open 465 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/9909](https://github.com/adafruit/circuitpython/pull/9909) (Open 440 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 399 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 320 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 304 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 258 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10474](https://github.com/adafruit/circuitpython/pull/10474) (Open 240 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 232 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 226 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10540](https://github.com/adafruit/circuitpython/pull/10540) (Open 219 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 219 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10571](https://github.com/adafruit/circuitpython/pull/10571) (Open 202 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 186 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10646](https://github.com/adafruit/circuitpython/pull/10646) (Open 161 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 144 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10674](https://github.com/adafruit/circuitpython/pull/10674) (Open 143 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10778](https://github.com/adafruit/circuitpython/pull/10778) (Open 48 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 40 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 36 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10844](https://github.com/adafruit/circuitpython/pull/10844) (Open 13 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 11 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10868](https://github.com/adafruit/circuitpython/pull/10868) (Open 4 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10874](https://github.com/adafruit/circuitpython/pull/10874) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10873](https://github.com/adafruit/circuitpython/pull/10873) (Open 2 days)  
+* 3 closed issues by 2 people, 5 opened by 5 people  
+* 847 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.1.x: 4 open issues  
+* 10.2.0: 1 open issues  
+* 10.x.x: 105 open issues  
+* 11.0.0: 10 open issues  
+* Libraries: 16 open issues  
+* Long term: 674 open issues  
+* Support: 21 open issues  
+* Third-party: 15 open issues  
+* 1 issues not assigned a milestone
+
+### 7:50 Libraries
+
+* Adafruit Libraries: 384 Community Libraries: 174 (Total: 558\)  
+* 5 pull requests merged  
+  * 3 authors \- tekktrik, FoamyGuy, BlitzCityDIY  
+  * 2 reviewers \- FoamyGuy, tannewt  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_MatrixPortal/pull/106](https://github.com/adafruit/Adafruit_CircuitPython_MatrixPortal/pull/106) (Days open: 35\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Wiznet5k/pull/189](https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k/pull/189) (Days open: 34\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Display\_Text/pull/237](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/pull/237) (Days open: 6\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bundle/pull/535](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/535) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bundle/pull/534](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/534) (Days open: 1\)  
+  * 38 open pull requests (Oldest: 1299, Newest: 7\)  
+* 2 closed issues by 1 people, 0 opened by 0 people  
+  * 770 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **New Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_Xteink\_X4](https://github.com/adafruit/Adafruit_CircuitPython_Xteink_X4)  
+  * [adafruit/Adafruit\_CircuitPython\_SSD1677](https://github.com/adafruit/Adafruit_CircuitPython_SSD1677)  
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_MatrixPortal](https://github.com/adafruit/Adafruit_CircuitPython_MatrixPortal)  
+  * [adafruit/Adafruit\_CircuitPython\_Display\_Text](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text)
+
+### 11:44 Blinka
+
+* 3 pull requests merged  
+  * 2 authors \- FoamyGuy, makermelissa  
+  * 2 reviewers \- tannewt, makermelissa  
+* 21 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1613 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 572 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 568 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/888](https://github.com/adafruit/Adafruit_Blinka/pull/888) (Open 555 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/908](https://github.com/adafruit/Adafruit_Blinka/pull/908) (Open 485 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 314 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/989](https://github.com/adafruit/Adafruit_Blinka/pull/989) (Open 246 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 132 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 132 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 132 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 132 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 132 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 59 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/1040](https://github.com/adafruit/Adafruit_Blinka/pull/1040) (Open 17 days)  
+  * [https://github.com/adafruit/Adafruit\_Python\_PlatformDetect/pull/409](https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/409) (Open 15 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/75](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/75) (Open 9 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/74](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/74) (Open 9 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/76](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/76) (Open 2 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 0 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/78](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/78) (Open 0 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/77](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/77) (Open 0 days)  
+* 0 closed issues by 0 people, 0 opened by 0 people  
+* 146 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 166
+
+## 12:40 Hug reports
+
+13:07 @danh (hosting)
+
+* Group hug\!
+
+13:25 @foamyguy
+
+* Group hug
+
+13:47 @tannewt
+
+* LIz for XTEink board def. Excited to try it on mine\!  
+* Ppsx for persisting to get qspi display support checked in.
+
+14:30 @tekktrik (not present)
+
+* @tannewt for the Zephyr native-sim test infrastructure in the core \- very helpful to reference for a reimplementation as a GitHub Action workflow  
+* Group hug\!
+
+## 14:48 Status Updates
+
+15:15 @danh (hosting)
+
+* Fixed an atmel-samd SPI bug that allowed incomplete SPI instances to be on the heap, causing crashes when finaliser ran.  
+* After the above bug is merged, I’ll do a 10.1.4 release.  
+* Finishing up a PR to make USB SD card access be more reliable:  
+  * SPI displays were not locking the bus properly.  
+  * SDCard was looping indefinitely while waiting for some SD operations.  
+  * On Espressif, separate USB task at a high priority was causing priority inversion hangs.  
+  * Interestingly, large SD cards can be really slow to use. I thought I had a bug when it turned out to just be the speed of a 64MB card vs a 16GB card.  
+* Started on MicroPython v1.27 merge. Not doing v1.26 as a separate merge because I think it would just be more work.
+
+18:16 @foamyguy
+
+* Fixed an issue with full-width glyphs only showing half the glyph with lvfontio  
+* Installed iNTERCEPT on Pi 4 & learn a bit about SDR stuff.  
+* CircuitPython driver and guide for APDS9999. Also working on hardware validation tests that can confirm the sensor is functioning as expected using NeoPixels to alter the lighting environment.
+
+20:30 @tannewt
+
+* Home with sick Rynn at least Monday. Depends on how she gets better.  
+* Merged in heap stat tracking in native\_sim and BLE connect and disconnect in native\_sim.  
+* Detouring into containers for GitHub actions and dev containers.  
+* Display work is blocked by SDL version mismatch between my local dev and GitHub actions. Containers should solve this and speed up github actions.  
+* Claude implemented BLE server but I haven’t looked at it.
+
+23:00 @tekktrik (not present)
+
+* Completed my initial implementation of a dataclasses library for CircuitPython  
+* [Prototyped running Zephyr native-sim tests for my dataclasses library](https://github.com/tekktrik/CircuitPython_Nitroclass/blob/dev/native-sim-tests/.github/workflows/simtest.yml) \- I created a [reusable GitHub Actions workflow](https://github.com/tekktrik/simulate-circuitpython) for actually running the Zephyr simulator and reading the output  
+  * Beginning the process of creating additional actions built on top of the reusable simulator workflow \- I’ll open a PR with a proof of concept to an example repository so folks can add their thoughts
+
+## 24:15 In The Weeds
+
+## 24:23 Wrap-Up
+
+The next meeting is Monday, March 16, 2026, at the usual time of 2 pm US ET / 11 am US PT. Note that the US switched to Daylight Saving Time on March 8\.  


### PR DESCRIPTION
Added notes from the CircuitPython Weekly Meeting on March 9, 2026, including community news, state of CircuitPython, and status updates.