### PR TITLE
Add CircuitPython Weekly Meeting notes for March 30, 2026

### DIFF
--- a/2026/2026-03-30.md
+++ b/2026/2026-03-30.md
@@ -1,0 +1,233 @@
+# CircuitPython Weekly Meeting for March 30, 2026
+
+Video is available [on YouTube](https://youtu.be/mbgUhrzYsX8).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 2:40 Community News
+
+### 2:47 The 2026 Python Developers Survey
+
+The ninth iteration of the official Python Developers Survey is out. Its goal is to show how the world of Python development looks today and how it compares to last year. It's rather important, especially for showing Python use in microcontroller and single board computer use (select "Embedded Development") \- [JetBrains.com](https://surveys.jetbrains.com/s3/python-developers-survey-2026). Via [BlueSky](https://bsky.app/profile/python.org/post/3mhv5hentjf24).
+
+### 3:15 Espressif News
+
+The Espressif ESP-IDF v6.0 is released, adding stable support for ESP32-C5 and ESP32-C61 RISC-V SoCs and preview support for ESP32-H21 and ESP32-H4 low-power wireless microcontrollers \- [Espressif](https://release-notes.espressif.tools/release/6.0) and [CNX](https://www.cnx-software.com/2026/03/24/esp-idf-v6-0-framework-adds-support-for-esp32-c5-and-esp32-c61-preview-for-esp32-h21-and-esp32-h4/). Via [Adafruit Blog](https://blog.adafruit.com/2026/03/24/the-espressif-esp-idf-v6-0-is-released-supporting-new-chips/).
+
+The ESP32-P4 microcontroller revision 3.0 gains a new power rail and requires PCB & firmware changes \- [CNX](https://www.cnx-software.com/2026/03/23/esp32-p4-revision-3-0-gains-new-power-rail-requires-new-pcb-design-and-firmware/). Via [Adafruit Blog](https://blog.adafruit.com/2026/03/24/esp32-p4-revision-3-0-gains-a-new-power-rail-and-requires-pcb-firmware-changes/).
+
+### 3:46 ‘Cool Stuff’ That Makes a Difference
+
+A new article on Associate Professor John Gallaugher and his students at Boston College, focusing on their work with assistive technology, which includes using CircuitPython \- [Boston College](https://www.bc.edu/content/bc-web/sites/bc-news/articles/2026/spring/the-class-that-makes-a-difference-.html).
+
+"'Tech for Good' is open to students from across the University, with no prerequisites. Last fall’s cohort included several graduate students from the Lynch School, an MBA student, and undergraduates majoring in computer science, marketing, and human-centered engineering. Every week, they gathered in the prototyping studio at the Hatchery, BC’s state-of-the-art makerspace. For many, it was their first time writing code or even hearing the word “accelerometer” (a device that measures movement)."
+
+### 4:31 A Popular Python Library Became a Backdoor to Malware
+
+LiteLLM is one of the most popular Python libraries for interacting with large language models (LLM), offering a single unified interface to forward requests to OpenAI compatible endpoints, Anthropic, Google, and dozens of other providers through a single wrapper. It has over 40,000 stars on GitHub, and it's an important dependency in a lot of AI tooling. It's also been compromised on PyPI, and the malicious versions are stealing everything they can find on your machine. On March 24, 2026, version 1.82.8 of LiteLLM was pushed to PyPI containing a malicious .pth file called "litellm\_init.pth". That file executes automatically on every Python process startup, meaning you don't even need to import the library for it to run. What's more, version 1.82.7 has also been compromised \- [XDA](https://www.xda-developers.com/popular-python-library-backdoor-machine/).
+
+### 5:45 A New Port of MicroPython to Amiga
+
+It's been 18 months since [reporting last](https://github.com/jyoberle/micropython-amiga) on an AmigaOS port of MicroPython. Fabrice has a new port of MicroPython v1.27.0 for Motorola 68020+ processors. It runs on classic Amiga hardware (A1200, A3000, A4000) and emulators (WinUAE, FS-UAE) \- [GitHub](https://github.com/OoZe1911/micropython-amiga-port) and Aminet. Via [Ganeration Amiga](https://www.generationamiga.com/2026/03/26/micropython-in-development-for-the-commodore-amiga-a-modern-language-on-classic-hardware/).
+
+### 6:25 The SPOKE Board Gains a New IDE and Distributor
+
+The [SPOKE CircuitPython multifunction board](https://www.spokeboard.com/) now has a new [web-based development environment](https://tom-vulpes.github.io/SpokeWebMidi/playground.html). After a successful Kickstarter, it is being manufactured in the UK and will be available from Pimoroni in coming weeks \- [BlueSky](https://bsky.app/profile/vulpeslabs.bsky.social/post/3mhbskjtwks2y).
+
+### 6:45 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 7:22 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 7:48 Overall
+
+* 18 pull requests merged  
+  * 8 authors \- relic-se, FoamyGuy, BlitzCityDIY, tekktrik, prcutler, tannewt, weblate, mikeysklar  
+  * 5 reviewers \- FoamyGuy, BlitzCityDIY, tekktrik, dhalbert, makermelissa  
+* 4 closed issues by 4 people, 5 opened by 5 people
+
+### 8:31 Core
+
+* 2 pull requests merged  
+  * 2 authors \- weblate, tannewt  
+  * 1 reviewers \- dhalbert  
+* 24 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 583 days)  
+  * [https://github.com/adafruit/circuitpython/pull/9844](https://github.com/adafruit/circuitpython/pull/9844) (Open 486 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/9909](https://github.com/adafruit/circuitpython/pull/9909) (Open 461 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 420 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 341 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 325 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 279 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10474](https://github.com/adafruit/circuitpython/pull/10474) (Open 261 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 253 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 247 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10540](https://github.com/adafruit/circuitpython/pull/10540) (Open 240 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 240 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10571](https://github.com/adafruit/circuitpython/pull/10571) (Open 223 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 207 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10646](https://github.com/adafruit/circuitpython/pull/10646) (Open 182 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 165 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10674](https://github.com/adafruit/circuitpython/pull/10674) (Open 164 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 61 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 57 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 32 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10895](https://github.com/adafruit/circuitpython/pull/10895) (Open 8 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10897](https://github.com/adafruit/circuitpython/pull/10897) (Open 5 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10899](https://github.com/adafruit/circuitpython/pull/10899) (Open 4 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10900](https://github.com/adafruit/circuitpython/pull/10900) (Open 2 days)  
+* 2 closed issues by 2 people, 4 opened by 4 people  
+* 853 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+  * 10.1.x: 3 open issues  
+  * 10.2.0: 1 open issues  
+  * 10.x.x: 111 open issues  
+  * 11.0.0: 10 open issues  
+  * Libraries: 16 open issues  
+  * Long term: 675 open issues  
+  * Support: 19 open issues  
+  * Third-party: 15 open issues  
+* 3 issues not assigned a milestone
+
+### 9:38 Libraries
+
+* Adafruit Libraries: 392 Community Libraries: 177 (Total: 569\)  
+* 14 pull requests merged  
+  * 6 authors \- relic-se, prcutler, FoamyGuy, BlitzCityDIY, tekktrik, mikeysklar  
+  * 3 reviewers \- tekktrik, FoamyGuy, BlitzCityDIY  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_TMAG5273/pull/1](https://github.com/adafruit/Adafruit_CircuitPython_TMAG5273/pull/1) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_ADS122C04/pull/1](https://github.com/adafruit/Adafruit_CircuitPython_ADS122C04/pull/1) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_ST7735R/pull/39](https://github.com/adafruit/Adafruit_CircuitPython_ST7735R/pull/39) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_VCNL4030/pull/1](https://github.com/adafruit/Adafruit_CircuitPython_VCNL4030/pull/1) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_BLE/pull/220](https://github.com/adafruit/Adafruit_CircuitPython_BLE/pull/220) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bundle/pull/546](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/546) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bundle/pull/545](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/545) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bundle/pull/544](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/544) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bundle/pull/543](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/543) (Days open: 1\)  
+    * [https://github.com/adafruit/CircuitPython\_Community\_Bundle/pull/277](https://github.com/adafruit/CircuitPython_Community_Bundle/pull/277) (Days open: 1\)  
+    * [https://github.com/adafruit/CircuitPython\_Community\_Bundle/pull/276](https://github.com/adafruit/CircuitPython_Community_Bundle/pull/276) (Days open: 1\)  
+    * [https://github.com/adafruit/CircuitPython\_Community\_Bundle/pull/275](https://github.com/adafruit/CircuitPython_Community_Bundle/pull/275) (Days open: 1\)  
+    * [https://github.com/adafruit/CircuitPython\_Community\_Bundle/pull/274](https://github.com/adafruit/CircuitPython_Community_Bundle/pull/274) (Days open: 1\)  
+    * [https://github.com/adafruit/CircuitPython\_Community\_Bundle/pull/273](https://github.com/adafruit/CircuitPython_Community_Bundle/pull/273) (Days open: 1\)  
+  * 35 open pull requests (Oldest: 1320, Newest: 10\)  
+* 1 closed issues by 1 people, 1 opened by 1 people  
+  * 772 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### 14:02 Library updates in the last seven days:
+
+* **New Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_VCNL4030](https://github.com/adafruit/Adafruit_CircuitPython_VCNL4030)  
+  * [adafruit/Adafruit\_CircuitPython\_TMAG5273](https://github.com/adafruit/Adafruit_CircuitPython_TMAG5273)  
+  * [tekktrik/CircuitPython\_Nitroclass](https://github.com/tekktrik/CircuitPython_Nitroclass)  
+  * [prcutler/CircuitPython\_bambulabs](https://github.com/prcutler/CircuitPython_bambulabs)  
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_NeoPixel](https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel)  
+  * [adafruit/Adafruit\_CircuitPython\_VCNL4030](https://github.com/adafruit/Adafruit_CircuitPython_VCNL4030)  
+  * [adafruit/Adafruit\_CircuitPython\_YotoPlayer](https://github.com/adafruit/Adafruit_CircuitPython_YotoPlayer)  
+  * [adafruit/Adafruit\_CircuitPython\_ST7735R](https://github.com/adafruit/Adafruit_CircuitPython_ST7735R)
+
+### 14:34 Blinka
+
+* 2 pull requests merged  
+  * 1 authors \- tekktrik  
+  * 1 reviewers \- makermelissa  
+* 19 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1634 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 593 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 589 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/888](https://github.com/adafruit/Adafruit_Blinka/pull/888) (Open 576 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/908](https://github.com/adafruit/Adafruit_Blinka/pull/908) (Open 506 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 336 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/989](https://github.com/adafruit/Adafruit_Blinka/pull/989) (Open 267 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 153 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 153 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 153 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 153 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 153 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 80 days)  
+  * [https://github.com/adafruit/Adafruit\_Python\_PlatformDetect/pull/409](https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/409) (Open 36 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/75](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/75) (Open 30 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/74](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/74) (Open 30 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/76](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/76) (Open 23 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 21 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/77](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/77) (Open 21 days)  
+* 1 closed issues by 1 people, 0 opened by 0 people  
+* 146 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 166
+
+## 15:22 Hug reports
+
+15:55 @tannewt (host)
+
+* @todbot for adding more synthy stuff to CP. (MCP DAC playback and speed changer)  
+* @tekktrik for setting up Zephyr native\_sim memory tracking github action.
+
+16:30 @danh
+
+* Timeline (forums) and Marshal (discord) for helping many users.
+
+17:03 @foamyguy
+
+* Paul Cutler for hosting a Fruit Jam discussion between Cooper, Dan C, and myself and cutting it together into an upcoming episode of the podcast. And another one for publishing a library to the community bundle  
+* @tekktrik for preparing some infrastructure update patches & for PR reviews
+
+17:38 @Paul Cutler (text only)
+
+* Todbot, gamblor, and foamyguy for help answering my questions as I worked on my first library for the Community Bundle  
+* Foamyguy for quickly publishing my PR to the community bundle \- that was fast\! :) 
+
+
+## 18:01 Status Updates
+
+18:23 @tannewt (host)
+
+* Out most of last week for a birthday trip.  
+* Zephyr displayio support was merged in.  
+* Can now rebase I2S support onto the display support.  
+* Need to split out flash fixes from larger mcuboot/uf2 changes. Also have a fix for the feather nrf52840 which makes the uf2 actually work. (It only worked when flashed directly.)  
+* BLE GATT support testing on device didn’t go well. I suspect the above flash fixes are needed.  
+* IDF6 update is continuing. Currently Claude is updating esp-camera.  
+* Sketched out a native `Awaitable` object that can be used for asyncio compatible native interfaces. It calls `_start`, \_end and \_cancel C functions based on the lifecycle and has a flag with a macro to indicate when it is done.  
+* Got my mac mini running and updated. Bought new ubiquiti router to help isolate it and test devices from my other comps.
+
+21:47 @danh
+
+* MicroPython v1.27 merge: finished initial merges, and proofreading those and the automatic merges. Next steps are to do builds and tests.
+
+22:55 @foamyguy
+
+* Raspberry Pi network bridge project  
+* Ran two library patches and release sweep for them  
+* Testing around APDS9999 breakout interrupt issue and starting hardware tests for it  
+* Made an easter egg hunt maze game
+
+26:16 @Paul Cutler (text only)
+
+* Published my first CircuitPython library: bambulabs \- it connects to a Bambu Labs 3D printer via MQTT, handles the MQTT setup for the user, and parses the JSON response in easy to read methods. I [blogged about it](https://www.paulcutler.org/blog/2026/03/29/bambu-labs-circuitpython-library/) and my experience [creating a library](https://www.paulcutler.org/blog/2026/03/30/circuitpython-bambulabs-published/)
+
+## 26:44 In The Weeds
+
+* 27:02 @tannewt \- Zephyr testing desires?  
+  * Feather Sense nRF52840  
+  * Pico build
+
+## 32:25 Wrap-Up
+


### PR DESCRIPTION
Added notes and updates from the CircuitPython Weekly Meeting held on March 30, 2026, including community news, development updates, and status reports.