### PR TITLE
Add minutes for CircuitPython Weekly Meeting on April 13

### DIFF
--- a/2026/2026-04-13.md
+++ b/2026/2026-04-13.md
@@ -1,0 +1,187 @@
+# CircuitPython Weekly Meeting for April 13, 2026
+
+Video is available [on YouTube](https://youtu.be/3zraME_h0jU).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 2:05 Community News
+
+## 2:30 MicroPython v1.28.0 is Out\!
+
+MicroPython lead developer Damien George has posted a new release, version v1.28.0. – [MicroPython GitHub](https://adafruitdaily.us10.list-manage.com/track/click?u=86903b65c84293425f40fa9a5&id=9507ecb163&e=e5fefcd6af). Via [Adafruit Blog](https://adafruitdaily.us10.list-manage.com/track/click?u=86903b65c84293425f40fa9a5&id=cb4a7f037c&e=e5fefcd6af). This release includes `machine.PWM` support for the stm32 and alif ports. A new `machine.CAN` implementation is also available. This release also sees the addition of template strings as per PEP 750\. An outline of MicroPython’s design values has been added to the main README.
+
+## 3:47 RAM Prices Are Threatening the Viability of the Raspberry Pi and Single-Board Computing
+
+The whole point of single-board computers was their affordability. Raspberry Pi, in particular, describes its mission as “\[putting\] high-performance, low-cost, general-purpose computing platforms in the hands of enthusiasts and engineers all over the world” – [Gizmodo](https://adafruitdaily.us10.list-manage.com/track/click?u=86903b65c84293425f40fa9a5&id=415c770bf0&e=e5fefcd6af).
+
+## 4:38 An MCP server for MicroPython
+
+There’s been a growing trend to connect Large Language Models (LLM) to various tools and systems. Physical devices like microcontrollers can become quite interesting when running LLMs with attached hardware. So Yusuke Sasaki has implemented an MCP server that allows direct code execution from an LLM on a board running MicroPython – [Switch Science](https://adafruitdaily.us10.list-manage.com/track/click?u=86903b65c84293425f40fa9a5&id=7d1d48b6b3&e=e5fefcd6af) and [GitHub](https://adafruitdaily.us10.list-manage.com/track/click?u=86903b65c84293425f40fa9a5&id=c70ff8150e&e=e5fefcd6af). (Japanese)
+
+## 5:18 Find MicroPython Packages with Mim
+
+If you are looking for a MicroPython package to do something you need, mim by Corella Creations, is very handy. It not only lists libraries and has a quick search feature, but it also provides the mip/mpremote commands to install each library – [checkmim.com](https://adafruitdaily.us10.list-manage.com/track/click?u=86903b65c84293425f40fa9a5&id=527b22ab00&e=e5fefcd6af). Via [X](https://adafruitdaily.us10.list-manage.com/track/click?u=86903b65c84293425f40fa9a5&id=7740e61448&e=e5fefcd6af).
+
+### 5:53 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 6:39 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 7:03 Overall
+
+* 9 pull requests merged  
+  * 6 authors \- tannewt, tekktrik, **ChrisNourse**, brentru, FoamyGuy, makermelissa  
+  * 5 reviewers \- ladyada, tannewt, FoamyGuy, makermelissa, dhalbert  
+* 4 closed issues by 3 people, 6 opened by 6 people
+
+### 7:34 Core
+
+* 6 pull requests merged  
+  * 3 authors \- FoamyGuy, tannewt, ChrisNourse  
+  * 2 reviewers \- tannewt, dhalbert  
+* 27 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 597 days)  
+  * [https://github.com/adafruit/circuitpython/pull/9844](https://github.com/adafruit/circuitpython/pull/9844) (Open 500 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/9909](https://github.com/adafruit/circuitpython/pull/9909) (Open 475 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 434 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 355 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 339 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 293 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10474](https://github.com/adafruit/circuitpython/pull/10474) (Open 275 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 267 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 261 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 254 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10571](https://github.com/adafruit/circuitpython/pull/10571) (Open 237 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 221 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 179 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10674](https://github.com/adafruit/circuitpython/pull/10674) (Open 178 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 75 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 71 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 46 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10899](https://github.com/adafruit/circuitpython/pull/10899) (Open 18 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10906](https://github.com/adafruit/circuitpython/pull/10906) (Open 13 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 12 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10922](https://github.com/adafruit/circuitpython/pull/10922) (Open 9 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10923](https://github.com/adafruit/circuitpython/pull/10923) (Open 6 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10931](https://github.com/adafruit/circuitpython/pull/10931) (Open 3 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10929](https://github.com/adafruit/circuitpython/pull/10929) (Open 3 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10933](https://github.com/adafruit/circuitpython/pull/10933) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10935](https://github.com/adafruit/circuitpython/pull/10935) (Open 1 days)  
+* 0 closed issues by 0 people, 4 opened by 4 people  
+* 858 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.1.x: 4 open issues  
+* 10.2.0: 1 open issues  
+* 10.x.x: 114 open issues  
+* 11.0.0: 10 open issues  
+* Libraries: 16 open issues  
+* Long term: 677 open issues  
+* Support: 20 open issues  
+* Third-party: 15 open issues  
+* 1 issues not assigned a milestone
+
+### 9:15 Libraries
+
+* Adafruit Libraries: 392 Community Libraries: 177 (Total: 569\)  
+* 2 pull requests merged  
+  * 2 authors \- tekktrik, brentru  
+  * 2 reviewers \- ladyada, FoamyGuy  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/261](https://github.com/adafruit/cookiecutter-adafruit-circuitpython/pull/261) (Days open: 18\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_uBlox/pull/1](https://github.com/adafruit/Adafruit_CircuitPython_uBlox/pull/1) (Days open: 6\)  
+  * 37 open pull requests (Oldest: 1334, Newest: 1\)  
+* 2 closed issues by 2 people, 1 opened by 1 people  
+  * 771 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+### 13:40 Blinka
+
+* 1 pull requests merged  
+  * 1 authors \- makermelissa  
+  * 1 reviewers \- makermelissa  
+* 20 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1648 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 607 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 603 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/888](https://github.com/adafruit/Adafruit_Blinka/pull/888) (Open 590 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/908](https://github.com/adafruit/Adafruit_Blinka/pull/908) (Open 520 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 350 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/989](https://github.com/adafruit/Adafruit_Blinka/pull/989) (Open 281 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 167 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 167 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 167 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 167 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 167 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 94 days)  
+  * [https://github.com/adafruit/Adafruit\_Python\_PlatformDetect/pull/409](https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/409) (Open 50 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/75](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/75) (Open 44 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/74](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/74) (Open 44 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 35 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/77](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/77) (Open 35 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/80](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/80) (Open 9 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/82](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/82) (Open 5 days)  
+* 2 closed issues by 1 people, 1 opened by 1 people  
+* 96 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 166
+
+## 14:35 Hug reports
+
+14:59 @danh (hosting)
+
+* @foamyguy for fixing a problem with the bundle failing to build
+
+15:12 @foamyguy
+
+* @nis on discord for more help during stream  
+* @anecdata for testing i2ctarget rpi fix
+
+15:45 @tannewt
+
+* @foamyguy for the i2ctarget fix  
+* @drewtheogre for the positive feedback on the usbip bridge.  
+* @bablokb for the Pimoroni board definition.  
+* @mlupo for the good issue on startup time.
+
+## 16:22 Status Updates
+
+16:47 @danh (hosting)
+
+* I’m finishing up merging MicroPython v1.27 into CircuitPython, and submitted a draft PR. There are some issues with some zephyr tests.  
+* We’ll do a 10.2.0 release candidate after the MicroPython merge is added.
+
+18:07 @foamyguy
+
+* Using a RPi as a router guide published  
+* MAX44009 driver written and basic tests check out, working on guide next then a more thorough pass over the hardware tests  
+* Looked into adabot bundle update issue  
+* Testing some experiments with nullclaw on raspberry pi  
+* Diving further into zephyr port: set up a containerfile and some scripts for building native\_sim and running tests  in a container. Enabled core modules: aesio, msgpack merged. Zlib, hashlib in a local branch with tests will PR soon. Adafruit\_bus\_device in a local branch manually tested  
+* I2ctarget fix for rpi port
+
+23:07 @tannewt
+
+* Heads down on USBIP bridge work and getting hardware-in-the-loop testing going. My bet is that I’ll be able to work faster with HIL for testing. For example, being able to automatically test RGBMatrix output would be awesome for the IDF6 update. My goal is to mirror the Zephyr native\_sim tests but with real hardware.
+
+## 25:29 In The Weeds
+
+## 25:50 Wrap-Up
+
+Next meeting is at the the normal time, next week, Monday, April 20, 2026, 2pm US ET, 11 am US PT.


### PR DESCRIPTION
Added the minutes for the CircuitPython Weekly Meeting held on April 13, 2026, including community news, updates on MicroPython, and various project status updates.