### PR TITLE
Add minutes for CircuitPython Weekly Meeting on April 27, 2026

### DIFF
--- a/2026/2026-04-27.md
+++ b/2026/2026-04-27.md
@@ -1,0 +1,210 @@
+# CircuitPython Weekly Meeting for April 27, 2026
+
+Video is available [on YouTube](https://youtu.be/GLe5Jn8sVHA).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 2:46 Community News
+
+### 2:54 Happy Birthday MicroPython\!
+
+We're celebrating MicroPython’s 13th birthday on April 29th\! \- [micropython.org](https://micropython.org/).
+
+Here are some important milestone dates provided in 2019 by Damien:
+
+* 29th April 2013: first line of code written (in private, before anyone knew about it, before it was even called MicroPython)  
+* 17th Sept 2013: first code running on a microcontroller, on the very first prototype of the pyboard  
+* 2nd Oct 2013: register micropython.org  
+* 4th Oct 2013: first commit in what is now the main repository  
+* late Dec 2013: source code up on GitHub  
+* 21st June 2014: last of the Kickstarter rewards sent out (for the first Kickstarter)  
+* 7th April 2026: MicroPython v1.28.0 released
+
+### 4:36 CircuitPython 10.2.0 Released
+
+CircuitPython 10.2.0 is a minor revision of CircuitPython and is a new stable release \- [Adafruit Blog](https://blog.adafruit.com/2026/04/22/circuitpython-10-2-0-released/) and Release Notes \- [GitHub](https://github.com/adafruit/circuitpython/releases/tag/10.2.0).
+
+**Highlights of This Release**
+
+* New `audiotools.SpeedChanger`.  
+* New `qspibus` support for `displayio`.  
+* Stability improvements to USB SD card handling.  
+* Merge of MicroPython v1.27.  
+* Update to ESP-IDF v5.5.3.  
+* Many additions to the Zephyr port.  
+* Simulated hardware testing is now being done in the Zephyr port.
+
+### 5:58 Exciting Python Features Are on the Way
+
+Transformative new Python features are coming in [Python 3.15](https://docs.python.org/3.15/whatsnew/3.15.html#). In addition to lazy imports and an immutable `frozendict` type, the new Python release will deliver significant improvements to the native [JIT compiler](https://www.infoworld.com/article/4110565/get-started-with-pythons-new-native-jit.html) and introduce a more explicit agenda for how Python will support [WebAssembly](https://www.infoworld.com/article/2255892/what-is-webassembly-the-next-generation-web-platform-explained.html) \- [InfoWorld](https://www.infoworld.com/article/4159295/exciting-python-features-are-on-the-way.html).
+
+### 6:36 Jumping Jerboa \- Transfer A Mouse+Keyboard To Other Computer
+
+This project is a combination of Python and CircuitPython scripts to transfer mouse and keyboard of your computer to another computer. A Raspberry Pi Pico is used as a USB HID Mouse/Keyboard \- [GitHub](https://github.com/rvl13/jumping-jerboa), [hackster.io](https://www.hackster.io/RVLAD/jumping-jerboa-transfer-mouse-keyboard-to-other-computer-68a134) and [YouTube](https://www.youtube.com/watch?v=6gO4RY2FTD8).
+
+### 7:08 MicroPython on LiteX Refreshed and Enhanced
+
+The LiteX fork of MicroPython has been refreshed and enhanced with new peripherals support \- [GitHub](https://github.com/litex-hub/micropython/tree/litex-rebase/ports/litex). Via [X](https://x.com/enjoy_digital/status/2047280807325118848).
+
+### 7:48 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 8:26 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 8:52 Overall
+
+* 20 pull requests merged  
+  * 7 authors \- FoamyGuy, dhalbert, derenrich, kylefmohr, mikeysklar, makermelissa-piclaw, jerryneedell  
+  * 5 reviewers \- FoamyGuy, makermelissa, tannewt, dhalbert, BlitzCityDIY  
+* 15 closed issues by 6 people, 2 opened by 2 people
+
+### 9:33 Core
+
+* 8 pull requests merged  
+  * 4 authors \- FoamyGuy, dhalbert, mikeysklar, kylefmohr  
+  * 2 reviewers \- tannewt, dhalbert  
+* 25 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 611 days)  
+  * [https://github.com/adafruit/circuitpython/pull/9844](https://github.com/adafruit/circuitpython/pull/9844) (Open 514 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/9909](https://github.com/adafruit/circuitpython/pull/9909) (Open 489 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 448 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 369 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 353 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 307 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 281 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 275 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 268 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10571](https://github.com/adafruit/circuitpython/pull/10571) (Open 251 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 235 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 193 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10674](https://github.com/adafruit/circuitpython/pull/10674) (Open 192 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 89 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 85 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 60 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10899](https://github.com/adafruit/circuitpython/pull/10899) (Open 32 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10906](https://github.com/adafruit/circuitpython/pull/10906) (Open 27 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 26 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10922](https://github.com/adafruit/circuitpython/pull/10922) (Open 23 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10935](https://github.com/adafruit/circuitpython/pull/10935) (Open 15 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10951](https://github.com/adafruit/circuitpython/pull/10951) (Open 10 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10963](https://github.com/adafruit/circuitpython/pull/10963) (Open 5 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10967](https://github.com/adafruit/circuitpython/pull/10967) (Open 4 days)  
+* 5 closed issues by 4 people, 1 opened by 1 people  
+* 860 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 7 active milestones  
+* 10.2.x: 3 open issues  
+* 10.x.x: 115 open issues  
+* 11.0.0: 10 open issues  
+* Libraries: 16 open issues  
+* Long term: 681 open issues  
+* Support: 20 open issues  
+* Third-party: 15 open issues  
+* 0 issues not assigned a milestone
+
+### 11:25 Libraries
+
+* Adafruit Libraries: 393 Community Libraries: 176 (Total: 569\)  
+* 5 pull requests merged  
+  * 4 authors \- FoamyGuy, jerryneedell, mikeysklar, **derenrich**  
+  * 4 reviewers \- BlitzCityDIY, tannewt, dhalbert, FoamyGuy  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_RFM/pull/22](https://github.com/adafruit/Adafruit_CircuitPython_RFM/pull/22) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_RFM9x/pull/100](https://github.com/adafruit/Adafruit_CircuitPython_RFM9x/pull/100) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_SGP41/pull/2](https://github.com/adafruit/Adafruit_CircuitPython_SGP41/pull/2) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_UC8151D/pull/16](https://github.com/adafruit/Adafruit_CircuitPython_UC8151D/pull/16) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_PyBadger/pull/74](https://github.com/adafruit/Adafruit_CircuitPython_PyBadger/pull/74) (Days open: 1\)  
+  * 36 open pull requests (Oldest: 1348, Newest: 2\)  
+* 2 closed issues by 2 people, 1 opened by 1 people  
+  * 773 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_UC8151D](https://github.com/adafruit/Adafruit_CircuitPython_UC8151D)  
+  * [adafruit/Adafruit\_CircuitPython\_YotoPlayer](https://github.com/adafruit/Adafruit_CircuitPython_YotoPlayer)
+
+### 14:34 Blinka
+
+* 7 pull requests merged  
+  * 1 authors \- makermelissa-piclaw  
+  * 1 reviewers \- makermelissa  
+* 16 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1662 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 621 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 617 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/908](https://github.com/adafruit/Adafruit_Blinka/pull/908) (Open 534 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 364 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 181 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 181 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 181 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 181 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 181 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 108 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/75](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/75) (Open 58 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/74](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/74) (Open 58 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 49 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/77](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/77) (Open 49 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/80](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/80) (Open 23 days)  
+* 8 closed issues by 1 people, 0 opened by 0 people  
+* 85 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 174
+
+## 15:29 Hug reports
+
+15:49 @tannewt (host)
+
+* @foamyguy for the last minute deep dive hosting while I was out with a sick kid.
+
+16:04 @danh
+
+* @foamyguy for helping me get my zephyr native\_sim build working.
+
+16:40 @foamyguy
+
+* @Noe for sharing some small GIF files to test on a device with limited RAM  
+* @i2cjak on discord for tips while working on a zephyr board def
+
+## 17:26 Status Updates
+
+17:39 @tannewt (host)
+
+* Been in a bit of a hardware rabbit hole. Two main goals:  
+  * Get ESP32-P4 design experience to use with Adafruit products.  
+  * Get an ESP32-P4 based hardware-in-the-loop (HIL) board going to make testing across platforms easy. (Testing protomatter changes in IDF6 branch across all ESPs is a first goal of mine.)  
+* Ordered my P4GPIO minimal design and am now working on the HIL version.
+
+20:17 @danh
+
+* Released CircuitPython 10.2.0, with various fixes. There are a number of bugs that were reported for 10.1.x that were not fixed in 10.2.0, but we are working on them. We wanted to do a release that included the ESP-IDF update and the MicroPython v1.27 merge before we moved on to more changes that might take longer to finish.  
+* I’ll do a 10.3.0-alpha.something soon so there’s a dev release to download.  
+* Working on ESP32-C6 crashing in memcpy(). This is complicated and hard to reproduce in a smaller program. LLM’s have been helpful with theories and churning through reproducing test programs. It may have to do with cache-line boundaries, or it may be a build configuration problem.  
+* Updated my regular dev machine to Ubuntu 26.04. It has caused no problems in CircuitPython development so far.
+
+25:14 @foamyguy
+
+* Ran patch to update ruff version and fixed all new failures. Committed a few fixes to the new patch workflow in adabot while using it.  
+* Wrote a guide for running iNTERCEPT on RPi  
+* Zephyr port: enabled gifio and storage modules, started working on metro rp2350 bard def. Needs some troubleshooting still  
+* Implementing audiobusio.I2SIn. Tested espressif port successfully on sparkle motion, parts otw to test the raspberrypi implementation.
+
+## 32:06 In The Weeds
+
+## 32:40 Wrap-Up
+


### PR DESCRIPTION
Added the minutes for the CircuitPython Weekly Meeting held on April 27, 2026, including community news, release updates, and status reports.