### PR TITLE
Add CircuitPython Weekly Meeting notes for May 11, 2026

### DIFF
--- a/2026/2026-05-11.md
+++ b/2026/2026-05-11.md
@@ -1,0 +1,176 @@
+# CircuitPython Weekly Meeting for May 11, 2026
+
+Video is available [on YouTube](https://youtu.be/JQgzeWP10cs).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 2:18 Community News
+
+### 3:11 Project of the Week: How to Reverse-Engineer Almost Any Keyboard Matrix With Raspberry Pi Pico
+
+thanishurs31 on Instructables has developed a Pi Pico and CircuitPython solution to scan an entire keyboard ribbon cable matrix. It figures out which pins are rows, which are columns, handles diode-protected N-key rollover boards and old simple membrane boards, flags shared power lines, and spits out a clean JSON map at the end – [Instructables](https://www.instructables.com/How-to-Reverse-Engineer-Almost-Any-Keyboard-Matrix/). Via [hackster.io](https://www.hackster.io/news/this-diy-gadget-automatically-deciphers-keyboard-matrices-a945f7fa2bc4).
+
+### 3:56 PulseTrain CircuitPython project
+
+James has created a CircuitPython program called PulseTrain specifically for the Raspberry Pi RP2040 Pico. The code uses the RP2040 PIO subsystem to generate exact pulse trains to drive a digital line, allowing an easy creation of common bitstreams used in many protocols – [Adafruit Blog](https://blog.adafruit.com/2026/05/05/creating-specific-pulse-trains-using-an-rp2040-pio-and-circuitpython/), [Substack](https://substack.com/home/post/p-195753914) and [GitHub](https://github.com/jamesbowman/rp2040-circuitpython-pulsetrain).
+
+### 4:32 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 5:19 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 5:40 Overall
+
+* 14 pull requests merged  
+  * 12 authors \- relic-se, BlitzCityDIY, FoamyGuy, **JonNelson**, **cyphra**, **jjuliano77**, **lzrd**, **ChrisNourse**, tannewt, weblate, **mikeysklar**, dhalbert  
+  * 4 reviewers \- gamblor21, tannewt, FoamyGuy, dhalbert  
+* 8 closed issues by 4 people, 9 opened by 9 people
+
+### 6:15 Core
+
+* 12 pull requests merged  
+  * 10 authors \- relic-se, JonNelson, cyphra, jjuliano77, lzrd, ChrisNourse, tannewt, weblate, mikeysklar, dhalbert  
+  * 3 reviewers \- dhalbert, gamblor21, tannewt  
+* 20 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 625 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 463 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 383 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 367 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 321 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 295 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 289 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 282 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 249 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 207 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10674](https://github.com/adafruit/circuitpython/pull/10674) (Open 206 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 103 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 99 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 74 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 40 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10992](https://github.com/adafruit/circuitpython/pull/10992) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10990](https://github.com/adafruit/circuitpython/pull/10990) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10989](https://github.com/adafruit/circuitpython/pull/10989) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10996](https://github.com/adafruit/circuitpython/pull/10996) (Open 0 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10995](https://github.com/adafruit/circuitpython/pull/10995) (Open 0 days)  
+* 7 closed issues by 3 people, 5 opened by 5 people  
+* 862 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.2.x: 2 open issues  
+* 10.3.0: 1 open issues  
+* 10.x.x: 118 open issues  
+* 11.0.0: 10 open issues  
+* Libraries: 16 open issues  
+* Long term: 679 open issues  
+* Support: 20 open issues  
+* Third-party: 15 open issues  
+* 1 issues not assigned a milestone
+
+### 7:50 Libraries
+
+* Adafruit Libraries: 393 Community Libraries: 176 (Total: 569\)  
+* 2 pull requests merged  
+  * 2 authors \- BlitzCityDIY, FoamyGuy  
+  * 2 reviewers \- FoamyGuy, tannewt  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Display\_Text/pull/238](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/pull/238) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_SEN6x/pull/7](https://github.com/adafruit/Adafruit_CircuitPython_SEN6x/pull/7) (Days open: 1\)  
+  * 36 open pull requests (Oldest: 1362, Newest: 4\)  
+* 1 closed issues by 1 people, 4 opened by 4 people  
+  * 777 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_SEN6x](https://github.com/adafruit/Adafruit_CircuitPython_SEN6x) \- SEN63C support  
+  * [adafruit/Adafruit\_CircuitPython\_Display\_Text](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text)
+
+### 12:00 Blinka
+
+* 0 pull requests merged  
+  * 0 authors \-  
+  * 0 reviewers \-  
+* 14 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1676 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 631 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 378 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 195 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 195 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 195 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 195 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 195 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 122 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/75](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/75) (Open 72 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/74](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/74) (Open 72 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 63 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/77](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/77) (Open 63 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/80](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/80) (Open 37 days)  
+* 0 closed issues by 0 people, 0 opened by 0 people  
+* 85 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 174
+
+## 13:25 Hug reports
+
+@danh (hosting)
+
+* @oenone (GitHub) for pin-pointing a problem in 10.2.0 for some boards with integral displays.  
+* @mikeysklar for working on issues with recent MagTag e-ink displays.
+
+14:20 @foamyguy
+
+* Dan for looking into C6 issues in recent core builds  
+* @relic-se for initial work on bi-directional I2S which was very helpful reference for new I2SIn effort  
+* Group hug
+
+15:11 @relic-se
+
+* @dhalbert for helping me get a hold of hardware to test some issues with the core\!
+
+@15:25 @tannewt
+
+* Cadet702 for hardware-in-the-loop excitement
+
+## 15:47 Status Updates
+
+16:11 @danh (hosting)
+
+* PR to allow turning off USB SD card presentation via \`CIRCUITPY\_SDCARD\_USB \= false\` in settings.toml.  
+* Fixed a 10.2.0 bug that will cause crashes on a number of boards with integral FourWire displays. I’ll do a 10.2.1 soon due to this.  
+* SAMD BOOT drives not appearing or broken on recent Linux:  
+  * This problem appears on Linux with fwupd v2.x.x, including recent ChromeOS and Ubuntu 26.04.  
+  * I have a fix (thanks LLMs), which adds a small amount of code. However, it causes overflow on several SAMD21 boards. I did some code squeezing which wasn’t sufficient. I moved the board URL from INDEX.HTM to INFO\_UF2.TXT, and that makes room.
+
+19:23 @foamyguy
+
+* Working on I2SIn, tested on more devices, fixed issues with raspberrypi port and S3 devices. Submitted PR with implementations for raspberrypi and espressif.  
+* Troubleshooting issue with bootlooping C6 devices on newest main builds  
+* Embodiment kit project: Found some cute face sprites and made tools to convert them from SVG to indexed png. Wrote displayio code to render them.
+
+22:55 @tannewt
+
+* Debugged the P4GPIO board. I hadn’t connected the flash power correctly. I have a v2 with the correction ready to order.  
+* P4HIL board has the same fix. Silkscreen is pretty much done. I want to adjust length of the RMII traces and check the USB ones as well. Then it is onto BOM for JLC. Shouldn’t take too long.  
+* Then, I’ll order both.  
+* After I’ll either fix IDF6 bugs, do something for Zephyr or work on the P4 logic analyzer stuff.
+
+## 24:54 In The Weeds
+
+## 25:00 Wrap-Up
+
+Normal day/time next week May 18\. Following week is on Tuesday May 26 for memorial day


### PR DESCRIPTION
Added notes from the CircuitPython Weekly Meeting held on May 11, 2026, including community news, project highlights, and status updates.