### PR TITLE
Add CircuitPython Weekly Meeting notes for May 18, 2026

### DIFF
--- a/2026/2026-05-18.md
+++ b/2026/2026-05-18.md
@@ -1,0 +1,195 @@
+# CircuitPython Weekly Meeting for May 18, 2026
+
+***Liz** is hosting.*
+
+Video is available on [YouTube](https://youtu.be/0_Ey1Wh1sXg).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## Community News
+
+### 01:51 CircuitPython 10.2.1 and CircuitPython 10.3.0-alpha.2 Released
+
+CircuitPython 10.2.1 and CircuitPython 10.3.0-alpha.2 have been released. They are bugfix revisions of CircuitPython \- [Adafruit Blog](https://blog.adafruit.com/2026/05/12/circuitpython-10-2-1-released/), release notes 10.2.1 \- [GitHub](https://github.com/adafruit/circuitpython/releases/tag/10.2.1), and release notes 10.3.0-alpha.2 \- [GitHub](https://github.com/adafruit/circuitpython/releases/tag/10.3.0-alpha.2).
+
+Highlights for Both Releases
+
+* Fix crashes on certain boards with integral displays.  
+* Adafruit MagTag 2025: improve display quality and support new display variant.
+
+Additional Highlights for 10.3.0-alpha.2
+
+* Add CIRCUITPY\_SDCARD\_USB to settings.toml to control visibility of a mounted SD card on USB.  
+* Support float values in settings.toml.  
+* Report USB MSC drives as removable media to the host.  
+* Update ESP-IDF to v6.0.1.  
+* Fix audiomixer.Mixer regressions on SAMx5x.  
+* STM: support audio.AudioOut using DAC.
+
+### 03:03 Project of the Week: A Little Computer That Writes Poems About Computers
+
+Yafira, electrocutelab on Instagram, has created ribbon\_logic (2026) \- [Instagram](https://www.instagram.com/p/DYOOEsBDG3m/?img_index=1).
+
+### 03:24 CircuitPython LED Matrix Info Display
+
+A tiny, always-on display using an Adafruit Matrix Portal S3 \+ 64×32 RGB LED matrix, coded in CircuitPython \- [guylewin.com](http://guylewin.com) and [GitHub](https://github.com/GuyLewin/matrixportal-concierge).
+
+### Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 04:08 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 04:21 Overall
+
+* 11 pull requests merged  
+  * 3 authors \- dhalbert, mikeysklar, tannewt  
+  * 2 reviewers \- dhalbert, tannewt  
+* 67 closed issues by 2 people, 8 opened by 6 people
+
+### 04:38 Core
+
+* 11 pull requests merged  
+  * 3 authors \- dhalbert, mikeysklar, tannewt  
+  * 2 reviewers \- dhalbert, tannewt  
+* 17 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 632 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 470 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 390 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 374 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 328 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 302 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 296 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 289 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 256 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 214 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 110 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 106 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 81 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 47 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10990](https://github.com/adafruit/circuitpython/pull/10990) (Open 9 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11008](https://github.com/adafruit/circuitpython/pull/11008) (Open 1 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11007](https://github.com/adafruit/circuitpython/pull/11007) (Open 1 days)  
+* 67 closed issues by 2 people, 4 opened by 3 people  
+* 800 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.2.x: 1 open issues  
+* 10.3.0: 0 open issues  
+* 10.x.x: 103 open issues  
+* 11.0.0: 11 open issues  
+* Libraries: 12 open issues  
+* Long term: 657 open issues  
+* Support: 5 open issues  
+* Third-party: 11 open issues  
+* 0 issues not assigned a milestone
+
+### 06:29 Libraries
+
+* Adafruit Libraries: 393 Community Libraries: 176 (Total: 569\)  
+* 0 pull requests merged  
+  * 0 authors \-  
+  * 0 reviewers \-  
+  * Merged pull requests:  
+  * 39 open pull requests (Oldest: 1369, Newest: 3\)  
+* 0 closed issues by 0 people, 4 opened by 4 people  
+  * 781 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **Updated Libraries**  
+  * [relic-se/CircuitPython\_TLV320AIC3204](https://github.com/relic-se/CircuitPython_TLV320AIC3204)  
+  * [relic-se/CircuitPython\_PIO\_I2S](https://github.com/relic-se/CircuitPython_PIO_I2S)
+
+### 10:00 Blinka
+
+* 0 pull requests merged  
+  * 0 authors \-  
+  * 0 reviewers \-  
+* 14 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/pull/40](https://github.com/adafruit/Adafruit_Blinka_bleio/pull/40) (Open 1683 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/pull/140](https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/140) (Open 638 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/22) (Open 385 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/15](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/15) (Open 202 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/14](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/14) (Open 202 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/13](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/13) (Open 202 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/12](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/12) (Open 202 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/11](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/11) (Open 202 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/70](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/70) (Open 129 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/75](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/75) (Open 79 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/74](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/74) (Open 79 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 70 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/77](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/77) (Open 70 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/80](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/80) (Open 44 days)  
+* 0 closed issues by 0 people, 0 opened by 0 people  
+* 85 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 174
+
+## 10:27 Hug reports
+
+10:42 @Liz (hosting)
+
+* Group hug
+
+10:46 @danh
+
+* @foamyguy for working on I2SIn.  
+* @tannewt for working on hardware-in-the-loop testing.
+
+11:18 @foamyguy
+
+* @relic-se for reviewing I2SIn and providing great feedback
+
+11:33 @relic-se (Cooper)
+
+* @foamyguy for making great progress on I2SIn.
+
+11:47 @tannewt
+
+* @danh for doing a pass over old bugs.  
+* Patrick McCanna for documenting wrapping Claude in bubblewrap: https://patrickmccanna.net/a-detailed-writeup-of-claude-code-constrained-by-bubblewrap/
+
+## 12:15 Status Updates
+
+12:33 @Liz (hosting)
+
+* I’ve been working on a drop-in PCB for the Ikea Alpstuga CO2 sensor. It uses an LED matrix for the display and they fit into a character mask in the enclosure. To get the placement correct, I brought in a picture of the PCB into Fusion360 and calibrated it so that it was sized correctly within Fusion. Then I could build out a sketch with all of the LEDs and mechanical parts. I also 3D print the sketch to test the sizing and placement of everything before I start working on the PCB layout.
+
+13:11 @danh
+
+* Released CircuitPython 10.2.1 last Tuesday and 10.3.0-alpha.2 last Friday..  
+* Closed 66 CircuitPython issues, mostly as stale, obsolete, or solved, in the past few days after reviewing a bunch of Support, Long Term, and 10.x.x issues. About 800 issues are open now.  
+* Three minor PR’s in process for next alpha release. Working on some more. Next set of major issues to look at involve Espressif BLE.  
+* Released fixed SAMD UF2 bootloader as v4.0.0. PR to update version on [circuitpython.org](http://circuitpython.org). Updating is necessary for ChromeOS and recent Linux.
+
+15:54 @foamyguy
+
+* A few more iterations on I2SIn. Added output\_bit\_depth and samples\_signed arguments, these allow simpler code for recording to wav files. Tested on more hardware and tried an issue reproducer script.  
+* Embodiment kit project: Hardware assembled, refactoring code, integrated all sensors and outputs with message handler, added custom face functionality, started writing the guide.
+
+17:59 @tannewt
+
+* JLC orders are expected to be completed on the 24th. (Waiting on the HIL board.)  
+* Working on getting all of the hardware-in-the-loop software side working.  
+* Was getting really frustrated with claude permissions and decided to make a Python script to wrap any command in bubblewrap (which claude uses for its sandbox). Then, I can run Claude without permissions checks. The CLI is `botbox`. Used udev rules to make device nodes for USB serial in `/dev/sandbox` so that folder can be shared into the sandbox. (Otherwise /dev would include lots of other things.)
+
+## In The Weeds
+
+## 20:44 Wrap-Up
+
+Next Monday is Memorial Day, CircuitPython meeting will be on Tuesday May, 26th


### PR DESCRIPTION
Added the CircuitPython Weekly Meeting notes for May 18, 2026, including community news, status updates, and project highlights.