### PR TITLE
Add CircuitPython Weekly Meeting notes for May 26, 2026

### DIFF
--- a/2026/2026-05-26.md
+++ b/2026/2026-05-26.md
@@ -1,0 +1,173 @@
+# CircuitPython Weekly Meeting for May 26, 2026
+
+Video is available on [YouTube](https://youtu.be/atOW_oh-7mw).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 2:47 Community News
+
+### 2:57 Mozilla and Adafruit Bring Web Serial Workflows to Firefox
+
+This week’s [Firefox 151 release](https://hacks.mozilla.org/2026/05/web-serial-support-in-firefox/) introduced support for the [Web Serial API on desktop](https://hacks.mozilla.org/2026/05/web-serial-support-in-firefox/). Many folks won’t use this API, but for our community of builders and tinkerers, it unlocks the ability to use Firefox to communicate directly with compatible hardware devices like microcontrollers, development boards, and other serial-connected devices \- [Distilled](https://blog.mozilla.org/en/firefox/firefox-web-serial-adafruit/).
+
+"With Firefox’s browser engine, Gecko, now supporting Web Serial, users can now connect, code, configure, and control compatible hardware directly from the browser in many workflows, often without additional software or complicated setup. As part of this week’s launch, [Adafruit](https://www.adafruit.com/), one of the internet’s most beloved open-source hardware communities, is collaborating with us to test and validate what browser-based hardware development can look like in Firefox with Web Serial support.   
+ 
+
+If you’ve ever spent time with CircuitPython, browser-based board programming, custom controllers, sensors, classroom kits, STEM homework assignments, or a desk covered in blinking microcontrollers—you probably already know Adafruit. With Web Serial support in Firefox 151, Adafruit’s browser-based hardware workflows now work directly in Firefox as well, with no additional software or complicated setup required for many projects. \[We invite you to give it a try\](https://adafruit.github.io/Adafruit\_WebSerial\_ESPTool/)."
+
+Related: Mozilla officially confirms Firefox 2026 "Nova" redesign, and you can already enable it \- [Neowin](https://www.neowin.net/news/mozilla-officially-confirms-firefox-2026-nova-redesign-and-you-can-already-enable-it/).
+
+### 4:47 Python Developers Update the *Guidelines For Using AI Tools*
+
+The guidelines for using AI tools when contributing to CPython has just been updated. Must read whether you're an existing or aspiring contributor. tl;dr: you're still responsible for what you submit \- [Python Developer's Guide](https://devguide.python.org/getting-started/ai-tools/). Via [LinkedIn](https://www.linkedin.com/posts/mariatta_python-share-7463076886668292096-Ufbv/).
+
+### 5:14 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 6:01 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 6:16 Overall
+
+* 25 pull requests merged  
+  * 11 authors \- mtraver, tyeth-ai-assisted, makermelissa-piclaw, Jah-yee, FoamyGuy, todbot, lehni, mikeysklar, dhalbert, dependabot\[bot\], douglaspkelly  
+  * 7 reviewers \- makermelissa-piclaw, tyeth, FoamyGuy, brentru, makermelissa, dhalbert, tannewt  
+* 14 closed issues by 4 people, 9 opened by 7 people
+
+### 7:09 Core
+
+* 7 pull requests merged  
+  * 4 authors \- dhalbert, makermelissa-piclaw, todbot, mikeysklar  
+  * 2 reviewers \- dhalbert, tannewt  
+* 18 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 640 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10023](https://github.com/adafruit/circuitpython/pull/10023) (Open 478 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 398 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 382 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 336 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 310 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 304 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 297 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 264 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 222 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 118 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 114 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10854](https://github.com/adafruit/circuitpython/pull/10854) (Open 89 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 55 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10990](https://github.com/adafruit/circuitpython/pull/10990) (Open 17 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11025](https://github.com/adafruit/circuitpython/pull/11025) (Open 3 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11028](https://github.com/adafruit/circuitpython/pull/11028) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11027](https://github.com/adafruit/circuitpython/pull/11027) (Open 2 days)  
+* 9 closed issues by 2 people, 7 opened by 6 people  
+* 798 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.2.x: 0 open issues  
+* 10.3.0: 60 open issues  
+* 10.x.x: 33 open issues  
+* 11.0.0: 13 open issues  
+* Libraries: 12 open issues  
+* Long term: 658 open issues  
+* Support: 5 open issues  
+* Third-party: 11 open issues  
+* 6 issues not assigned a milestone
+
+### 8:40 Libraries
+
+* Adafruit Libraries: 393 Community Libraries: 176 (Total: 569\)  
+* 4 pull requests merged  
+  * 4 authors \- **Jah-yee**, FoamyGuy, **mtraver**, mikeysklar  
+  * 5 reviewers \- tyeth, FoamyGuy, brentru, dhalbert, tannewt  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_SSD1680/pull/40](https://github.com/adafruit/Adafruit_CircuitPython_SSD1680/pull/40) (Days open: 8\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_MPU6050/pull/44](https://github.com/adafruit/Adafruit_CircuitPython_MPU6050/pull/44) (Days open: 2\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_MiniMQTT/pull/258](https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/pull/258) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bitmap\_Font/pull/76](https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font/pull/76) (Days open: 1\)  
+  * 40 open pull requests (Oldest: 1377, Newest: 4\)  
+* 3 closed issues by 3 people, 1 opened by 1 people  
+  * 782 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_MiniMQTT](https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT)  
+  * [adafruit/Adafruit\_CircuitPython\_MPU6050](https://github.com/adafruit/Adafruit_CircuitPython_MPU6050)  
+  * [adafruit/Adafruit\_CircuitPython\_SSD1680](https://github.com/adafruit/Adafruit_CircuitPython_SSD1680)  
+  * [relic-se/CircuitPython\_KeyManager](https://github.com/relic-se/CircuitPython_KeyManager)
+
+### Blinka
+
+* 14 pull requests merged  
+  * 5 authors \- makermelissa-piclaw, lehni, dependabot\[bot\], douglaspkelly, tyeth-ai-assisted  
+  * 3 reviewers \- dhalbert, makermelissa-piclaw, makermelissa  
+* 1 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 78 days)  
+* 2 closed issues by 1 people, 1 opened by 1 people  
+* 84 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues)  
+* Number of supported boards: 174
+
+## 14:12 Hug reports
+
+14:27 @tannewt (host)
+
+* Kelly, Julian and @todbot for the Teaching Python podcast. Really helpful to have a reminder that folks still find hard things about using CircuitPython. [https://www.teachingpython.fm/156](https://www.teachingpython.fm/156)
+
+15:01 @danh (out)
+
+* @mikeysklar for SD card fixes.
+
+15:13 @foamyguy
+
+* @johnnohj for pointing out a file I missed while working on web workflow integrations during a stream. It was the key to fixing what was wrong with the code at the time  
+* Anne and Liz for learn guide reviews and feedback
+
+15:51 @relic-se
+
+* @todbot for his work on \`audiospeed.SpeedChanger\` and helpful discussion on the topic.
+
+## 16:30 Status Updates
+
+16:47 @tannewt (host)
+
+* Last week was mostly spent on [https://breadboard.ing](https://breadboard.ing) which is basically fritzing on the web.  
+* P4HIL, P4GPIO v2 and 22x5 stemmas arrived from JLCPCB.  
+* Now, heads down on testing the board design to make sure it all works and then getting all usable for actual development and testing.
+
+18:44 @danh (out)
+
+* Fixed half a dozen minor issues last week.  
+* Now working on BLE regression on Espressif coincident with ESP-IDF 6.0.1 upgrade. There was already an issue with Nimble running out of memory on previous 10.x.x releases.
+
+19:12 @foamyguy
+
+* Embodiment kit guide pages  
+* Another iteration and testing on I2SIn  
+* Working on extending circuitpython-runner agent skill to support web workflow  
+* Found a problem with Memento device not being able to init camera on the latest versions of CircuitPython and created an issue for it.
+
+## 22:10 In The Weeds
+
+22:24 @relic-se
+
+* Audio module organization in upcoming \`audioi2sin.I2SIn\`  
+  * Example: \`audiobusio.PDMIn\` included with compiler flag \`CIRCUITPY\_AUDIOBUSIO\_PDMIN\`  
+* 25:55 Considerations on potential \`audiospeed.Resampler\` to handle sample rate, signedness, and bit depth compatibility
+
+## 29:54 Wrap-Up
+
+* Next week is normal Monday 2pm Eastern/11am Pacific. (June 1st)


### PR DESCRIPTION
Added the meeting notes for the CircuitPython Weekly Meeting on May 26, 2026, including community news, updates, and status reports.