### PR TITLE
Add CircuitPython Weekly Meeting notes for July 13, 2026

### DIFF
--- a/2026/2026-07-13.md
+++ b/2026/2026-07-13.md
@@ -1,0 +1,179 @@
+# CircuitPython Weekly Meeting for July 13, 2026
+
+Video is available on [YouTube](https://youtu.be/7LSWD2pDHOY).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 01:51 Community News
+
+Catch the latest episode of The Bootloader and hear [Paul Cutler](https://www.paulcutler.org/) discuss RV Circuit Studio, a new CircuitPython IDE that looks like a capable Mu replacement \- [Mastodon](https://mastodon.social/@prcutler@hachyderm.io/116885406664462393) and [Podcast](https://www.thebootloader.net/episodes/2026/ep034/).
+
+A system for growing and managing succulents where it displays measurement values from barometric pressure/temperature and humidity sensors, illuminance sensors, and soil sensors on an OLED display, while sending the data to kintone every 10 minutes \- [X](https://x.com/Masaki_Mizutani/status/2075238218350612617). (Japanese)
+
+A CircuitPython Adafruit Fruit Jam GIF video looper demonstration \- [YouTube](https://www.youtube.com/watch?v=gCZxLf8eJ-k) and [GitHub](https://github.com/relic-se/Fruit_Jam_VideoLooper).
+
+### Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 03:07 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 03:18 Overall
+
+* 29 pull requests merged  
+  * 10 authors \- LydoriaChan, Abhi-00047, mikeysklar, lydorianP, dependabot\[bot\], FoamyGuy, weblate, makermelissa, grgrant, dhalbert  
+  * 4 reviewers \- makermelissa, FoamyGuy, dhalbert, tannewt  
+* 16 closed issues by 4 people, 7 opened by 5 people
+
+### 03:47 Core
+
+* 13 pull requests merged  
+  * 7 authors \- LydoriaChan, Abhi-00047, FoamyGuy, weblate, dhalbert, mikeysklar, lydorianP  
+  * 2 reviewers \- dhalbert, tannewt  
+* 19 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 688 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 446 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 430 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 384 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 358 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10512](https://github.com/adafruit/circuitpython/pull/10512) (Open 352 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 345 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 312 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 270 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 166 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10796](https://github.com/adafruit/circuitpython/pull/10796) (Open 162 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 103 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11040](https://github.com/adafruit/circuitpython/pull/11040) (Open 41 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11104](https://github.com/adafruit/circuitpython/pull/11104) (Open 4 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11102](https://github.com/adafruit/circuitpython/pull/11102) (Open 4 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/11106](https://github.com/adafruit/circuitpython/pull/11106) (Open 3 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11110](https://github.com/adafruit/circuitpython/pull/11110) (Open 2 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11113](https://github.com/adafruit/circuitpython/pull/11113) (Open 0 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11112](https://github.com/adafruit/circuitpython/pull/11112) (Open 0 days)  
+* 12 closed issues by 2 people, 4 opened by 3 people  
+* 770 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.2.x: 0 open issues  
+* 10.3.0: 28 open issues  
+* 10.x.x: 35 open issues  
+* 11.0.0: 15 open issues  
+* Libraries: 12 open issues  
+* Long term: 664 open issues  
+* Support: 6 open issues  
+* Third-party: 11 open issues  
+* 0 issues not assigned a milestone
+
+### 05:41 Libraries
+
+* Adafruit Libraries: 395 Community Libraries: 177 (Total: 572\)  
+* 2 pull requests merged  
+  * 1 authors \- grgrant  
+  * 1 reviewers \- FoamyGuy  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_BMP5xx/pull/5](https://github.com/adafruit/Adafruit_CircuitPython_BMP5xx/pull/5) (Days open: 7\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_SCD30/pull/39](https://github.com/adafruit/Adafruit_CircuitPython_SCD30/pull/39) (Days open: 3\)  
+  * 41 open pull requests (Oldest: 1425, Newest: 10\)  
+* 2 closed issues by 1 people, 3 opened by 3 people  
+  * 782 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_BMP5xx](https://github.com/adafruit/Adafruit_CircuitPython_BMP5xx)  
+  * [adafruit/Adafruit\_CircuitPython\_SCD30](https://github.com/adafruit/Adafruit_CircuitPython_SCD30)  
+  * [relic-se/CircuitPython\_Synthiota](https://github.com/relic-se/CircuitPython_Synthiota)
+
+### 09:26 Blinka
+
+* 14 pull requests merged  
+  * 2 authors \- makermelissa, dependabot\[bot\]  
+  * 1 reviewers \- makermelissa  
+* 6 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 698 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 126 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/88](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/88) (Open 8 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/87](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/87) (Open 8 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/29](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/29) (Open 0 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/28](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/28) (Open 0 days)  
+* 2 closed issues by 1 people, 0 opened by 0 people  
+* 79 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues) (34)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/issues](https://github.com/adafruit/Adafruit_Blinka_Displayio/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/issues](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/issues](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/issues) (13)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/issues](https://github.com/adafruit/Adafruit_Blinka_bleio/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Python\_Extended\_Bus/issues](https://github.com/adafruit/Adafruit_Python_Extended_Bus/issues) (1)  
+  * [https://github.com/adafruit/Adafruit\_Python\_PlatformDetect/issues](https://github.com/adafruit/Adafruit_Python_PlatformDetect/issues) (1)  
+* Number of supported boards: 174
+
+## 09:56 Hug reports
+
+10:12 @Liz (hosting)
+
+* Tim for all of the audio work in the core  
+* Dan for closing out so many issues in the core  
+* Scott for upcoming HIL work  
+* Group hug
+
+10:36 @danh
+
+* @River (RIver Wang) for more work on their browser-based IDE  
+* @jepler for fixing old bugs and adding new features  
+* @foamyguy for audiofilewriter and other audio work
+
+11:22 @foamyguy
+
+* @relic-se for working on stereo support for usb\_audio  
+* Liz for kicad2fritzing tool  
+* @smitka for adding picodvi/Fruit Jam support to picogame and other improvements
+
+12:02 @tannewt
+
+* @jepler for memorymap changes and other fixes.
+
+## 12:19 Status Updates
+
+12:38 @Liz (hosting)
+
+* I published the kicad2fritzing and circuitpython chiptune player guides last week. The kicad2fritzing tool uses Python to convert KiCad PCB files to Fritzing parts. The chiptune guide uses a synthio helper library to emulate the AY-3-8910 chip for playing back video game music files  
+* This week I’m revisiting the Ikea Alpstuga drop-in board. I did some rework on rev A to confirm some issues to fix for rev B. I had the buttons routed incorrectly and all of the LEDs were placed backwards on the board, but the schematic and fab print were correct.
+
+13:25 @danh
+
+* Fixing and investigating more bugs for 10.3.0. Closed several as no longer broken. Less than 30 issues left now. USB Host regression which we’ll need to investigate.  
+* Will do another alpha release soon.
+
+14:46 @foamyguy
+
+* audiofilewriter module merged in core  
+* Tested picogame on Fruit Jam and worked on support for USB game controller  
+* Started implementing a class for granular pitch shifting. It’s a different technique that leads to less robotic sounding large shifts as compared to the existing PitchShift  
+* Wrote PoC code to make a Fruit Jam \+ Midi keyboard act like a Casio SK-1 sampler keyboard. Press a button to record a sample, then use the keyboard to play shifted versions of the sample. Working on support for midi track playback to have something akin to the demo song from the SK-1
+
+17:25 @tannewt
+
+* May be out some this week for my birthday.  
+* Working on gameboy cart software changes now that data, address and control pins are all in the same pin region for PIO.  
+* Also working on HIL setup webpage.  
+* Trackball PCBs will be ordered shortly because they need a respin.
+
+## In The Weeds
+
+## 18:37 Wrap-Up
+
+Normal day/time next week Monday 7/20 2pm Eastern 11am Pacific


### PR DESCRIPTION
Added notes from the CircuitPython Weekly Meeting on July 13, 2026, including community news, state of CircuitPython, libraries updates, and status reports.