### PR TITLE
Add CircuitPython Weekly Meeting notes for July 20, 2026

### DIFF
--- a/2026/2026-07-20.md
+++ b/2026/2026-07-20.md
@@ -1,0 +1,192 @@
+# CircuitPython Weekly Meeting for July 20, 2026
+
+Video is available [on YouTube](https://youtu.be/fi_--TWe0gA).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 1:56 Community News
+
+### 2:07 AMYboard \- a MicroPython-based Eurorack Module
+
+AMYboard is a complete audio synthesizer for US $29.90 that can be at least three things: a Synthesizer, Dev Board, and Eurorack module. It's open source, has a STEMMA QT/qwiic port for expansion, and ships with MicroPython firmware \- [AMYboard](https://www.amyboard.com/). Via [BlueSky](https://bsky.app/profile/johnnytacos.bsky.social/post/3mqks4bfptk23).
+
+### 2:35 MicroPython on the Super Nintendo
+
+Python on the SNES has been a dream of Fabian Kübler for a long time. Claude Fable 5 came out, and Fabian thought: this would make a great benchmark for the model. Porting MicroPython to the SNES: a 3.58 MHz CPU, 128 KB of RAM, 16-bit int, and a niche C compiler \- [Fabian Kübler](https://fabian-kuebler.com/posts/fable-python-snes/) and [GitHub](https://github.com/FabianKuebler/micropython-snes). Via [Adafruit Blog](https://blog.adafruit.com/2026/07/13/micropython-on-the-super-nintendo/).
+
+### 3:13 Comparing MicroPython, Zephyr, Lua, and Forth
+
+One of MicroPython’s best features is its REPL (“read-evaluate-print-loop”), which allows a person to write Python code and interact with their hardware, all from a serial connection. Lua and Forth are two other interpreted languages that came up in my research as being particularly well-suited for embedded systems. So, how do these tools (and the Zephyr shell) stack up against each other? \- [Maker.io](https://www.digikey.com/en/maker/blogs/2026/comparing-micropython-zephyr-lua-and-forth).
+
+### 3:47 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 4:20 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 4:37 Overall
+
+* 17 pull requests merged  
+  * 7 authors \- grgrant, mikeysklar, jepler, 94xhn, dhalbert, FoamyGuy, BlitzCityDIY  
+  * 4 reviewers \- dhalbert, FoamyGuy, tannewt, BlitzCityDIY  
+* 12 closed issues by 4 people, 3 opened by 3 people
+
+### 5:20 Core
+
+* 13 pull requests merged  
+  * 5 authors \- jepler, 94xhn, dhalbert, FoamyGuy, mikeysklar  
+  * 2 reviewers \- dhalbert, tannewt  
+* 15 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 695 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 453 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 437 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 391 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 365 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 352 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 319 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 277 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 173 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 110 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11040](https://github.com/adafruit/circuitpython/pull/11040) (Open 48 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11102](https://github.com/adafruit/circuitpython/pull/11102) (Open 11 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/11110](https://github.com/adafruit/circuitpython/pull/11110) (Open 9 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11124](https://github.com/adafruit/circuitpython/pull/11124) (Open 4 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11129](https://github.com/adafruit/circuitpython/pull/11129) (Open 2 days)  
+* 10 closed issues by 3 people, 2 opened by 2 people  
+* 766 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.2.x: 0 open issues  
+* 10.3.0: 23 open issues  
+* 10.x.x: 36 open issues  
+* 11.0.0: 15 open issues  
+* Libraries: 12 open issues  
+* Long term: 664 open issues  
+* Support: 6 open issues  
+* Third-party: 11 open issues  
+* 0 issues not assigned a milestone
+
+### 6:33 Libraries
+
+* Adafruit Libraries: 395 Community Libraries: 177 (Total: 572\)  
+* 4 pull requests merged  
+  * 4 authors \- dhalbert, FoamyGuy, grgrant, BlitzCityDIY  
+  * 3 reviewers \- FoamyGuy, tannewt, BlitzCityDIY  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_TMP117/pull/21](https://github.com/adafruit/Adafruit_CircuitPython_TMP117/pull/21) (Days open: 13\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_CST8XX/pull/5](https://github.com/adafruit/Adafruit_CircuitPython_CST8XX/pull/5) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_MIDI\_Parser/pull/5](https://github.com/adafruit/Adafruit_CircuitPython_MIDI_Parser/pull/5) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_asyncio/pull/75](https://github.com/adafruit/Adafruit_CircuitPython_asyncio/pull/75) (Days open: 1\)  
+  * 41 open pull requests (Oldest: 1432, Newest: 2\)  
+* 2 closed issues by 1 people, 1 opened by 1 people  
+  * 782 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **New Libraries**  
+  * [CircuitPython\_DS1302](https://github.com/Elfking29/CircuitPython_DS1302)  
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_asyncio](https://github.com/adafruit/Adafruit_CircuitPython_asyncio)  
+  * [adafruit/Adafruit\_CircuitPython\_TM](https://github.com/adafruit/Adafruit_CircuitPython_TM)  
+  * [adafruit/Adafruit\_CircuitPython\_MIDI\_Parser](https://github.com/adafruit/Adafruit_CircuitPython_MIDI_Parser)
+
+### 10:30 Blinka
+
+* 0 pull requests merged  
+  * 0 authors \-  
+  * 0 reviewers \-  
+* 9 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 705 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 133 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/88](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/88) (Open 15 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/87](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/87) (Open 15 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/29](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/29) (Open 7 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/28](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/28) (Open 7 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/22](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/22) (Open 6 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/21](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/21) (Open 6 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/30](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/30) (Open 0 days)  
+* 0 closed issues by 0 people, 0 opened by 0 people  
+* 79 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues) (34)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/issues](https://github.com/adafruit/Adafruit_Blinka_Displayio/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/issues](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/issues](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/issues) (13)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/issues](https://github.com/adafruit/Adafruit_Blinka_bleio/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Python\_Extended\_Bus/issues](https://github.com/adafruit/Adafruit_Python_Extended_Bus/issues) (1)  
+  * [https://github.com/adafruit/Adafruit\_Python\_PlatformDetect/issues](https://github.com/adafruit/Adafruit_Python_PlatformDetect/issues) (1)  
+* Number of supported boards: 174
+
+## 11:26 Hug reports
+
+12:00 @tannewt (host)
+
+* Mikeysklar for all of the LLM powered fixes. Very excited to see them experimenting with finding CP bugs with LLM.
+
+12:35 @danh
+
+* @mikeysklar for USB host fixes and comments on other issues and PRs  
+* @tannewt for discussions re settings.toml options
+
+13:30 @foamyguy
+
+* @smitka again for more work on picogame, and picking up on the gamepad work where I left off  
+* @relic-se and @danh for review and discussion on GranularPitchShift PR  
+* @danh for new USB storage capabilities  
+* Group hug
+
+14:11 @Liz
+
+* @FoamyGuy for assisting with the CST8XX library
+
+14:20 @todbot (text only, not present)
+
+* @jepler for native module (“natmod”) support  
+* @foamyguy for granular pitch shifter effect & audio file writer & sdio for rp2  
+* @relic-se for audio effect reviews and general synthio/audio stuff
+
+## 14:54 Status Updates
+
+15:20 @tannewt (host)
+
+* Still heads down on gameboy.  
+  * PIO \-\> DMA \-\> PIO is proven.  
+  * Now I need to connect the \_gbio API to the in-memory cart RAM.  
+  * Then, revive the old demos.  
+* Planning to attend Supercon 11/6-8. Will apply to speak probably on hardware in the loop and on the gameboy.
+
+16:59 @danh
+
+* More CircuitPython 10.3.0 fixes:   
+  * Lower tx\_power on chip antenna boards to 15 dBm.  
+  * update ulab  
+  * storage.disable\_usb\_drive() after code.py or REPL start; working with Scott on exact API  
+  * can now turn off BLE workflow with CIRCUITPY\_BLE\_WORKFLOW  
+* 10.3.0-alpha.4 soon
+
+19:17 @foamyguy
+
+* Wrote a guide for a USB midi keyboard sampler for Fruit Jam  
+* Reverse engineering TE ting fx ep-2350  
+  * Figured out the pinout and power control scheme  
+  * Micropython PoCs to control audio input and output  
+  * Started CircuitPython board def & writing NAU88L21 driver lib  
+  * Planning for I2S duplex support
+
+## 22:33 In The Weeds
+
+## 23:10 Wrap-Up
+


### PR DESCRIPTION
Added the CircuitPython Weekly Meeting notes for July 20, 2026, including community news, development updates, and status reports.