### PR TITLE
Add CircuitPython Weekly Meeting notes for August 3, 2026

### DIFF
--- a/2026/2026-08-03.md
+++ b/2026/2026-08-03.md
@@ -1,0 +1,201 @@
+# CircuitPython Weekly Meeting for August 3rd, 2026
+
+Video is available [on YouTube](https://youtu.be/NfdrL1WWtek).
+
+Join here for the chat all week: [http://adafru.it/discord](http://adafru.it/discord).
+
+The CircuitPython Weekly Meeting normally is held at 2pm US ET/11am PT on Mondays. Check the \#circuitpython channel on Discord for notices of change in time and links to past meetings. Meeting times are also available in [iCal format](https://raw.githubusercontent.com/adafruit/adafruit-circuitpython-weekly-meeting/master/meeting.ical) for use with standard calendar applications and can also be viewed [in your browser](https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fraw.githubusercontent.com%2Fadafruit%2Fadafruit-circuitpython-weekly-meeting%2Fmain%2Fmeeting.ical&title=CircuitPython%20Meeting%20Schedule&tab=agenda&tabs=month&tabs=agenda).
+
+If you want to be able to participate in the meeting by speaking, you will need to be added to the @circuitpythonistas role on Discord. Please ask any of the moderators or admins to add you if you’d like to join.
+
+CircuitPython development is sponsored by Adafruit. Please support them by purchasing hardware from https://adafruit.com.
+
+Reminders: Podcast available on most services. Let us know if we’re missing some. The canonical URL for the podcast version is [https://adafruit-podcasts.s3.amazonaws.com/circuitpython\_weekly\_meeting/audio-podcast.xml](https://adafruit-podcasts.s3.amazonaws.com/circuitpython_weekly_meeting/audio-podcast.xml) which you may be able to enter directly into compatible podcast apps.
+
+## 2:00 Community News
+
+### 2:35 CircuitPython Day will be August 21, 2026
+
+It’s that time of year\! Adafruit has determined that August 21, 2026 is the snakiest day of the year and designated it CircuitPython Day\! Adafruit will have special shows and more throughout the day. Tag your projects \#CircuitPythonDay2026 on social media and Adafruit will look to highlight them. Check out the schedule on the site as it’ll change as more content is announced – [Adafruit Blog](https://us.list-manage.com/13uk7wu9D2H?e=e5fefcd6af&c2id=1f5f398a5cb8199e162832af87ee2d29).
+
+### 3:34 Improving The Microcontroller Gaming Performance With PicoGame
+
+The ability to write Python on microcontrollers with the likes of MicroPython and later CircuitPython has made them much more accessible. MakerClassCZ brings that to game development with PicoGame. Like any good project, it starts with a problem that needs solving. Put simply, the existing CircuitPython displayio code isn’t that fast for gaming. It does a lot of work when computing a pixel. The \_stage module, which is simpler, wasn’t flexible enough for MakerClassCZ’s liking. So he built his own – [Hackaday](https://us.list-manage.com/3WZIMNLb3uj?e=e5fefcd6af&c2id=1f5f398a5cb8199e162832af87ee2d29) (note the Hackaday article oversimplifies a bit on some points).
+
+### 4:46 Newsletter Details
+
+The Python on Microcontrollers Weekly Newsletter is a CircuitPython-community-run newsletter emailed every Monday. The complete archives are [here](https://www.adafruitdaily.com/category/circuitpython/).  It highlights the latest Python on hardware related news from around the web including CircuitPython, Python and MicroPython developments. 
+
+To contribute your own news or project, email [cpnews@adafruit.com](mailto:cpnews@adafruit.com). We appreciate your contributions.
+
+## 5:30 State of CircuitPython, Libraries and Blinka
+
+**This report contains information from the previous seven days. Any changes (PRs merged, etc.) made today are not included in this report.**
+
+### 6:00 Overall
+
+* 28 pull requests merged  
+  * 12 authors \- giri256, grgrant, FoamyGuy, annejan, hueyalex, weblate, dhalbert, BlitzCityDIY, lynt-smitka, madmx5, makermelissa, CDarius  
+  * 6 reviewers \- dhalbert, tannewt, FoamyGuy, makermelissa, tekktrik, brentru  
+* 21 closed issues by 6 people, 10 opened by 7 people
+
+### 6:25 8:108Core
+
+* 14 pull requests merged  
+  * 7 authors \- weblate, dhalbert, BlitzCityDIY, lynt-smitka, FoamyGuy, annejan, CDarius  
+  * 2 reviewers \- dhalbert, tannewt  
+* 15 open pull requests  
+  * [https://github.com/adafruit/circuitpython/pull/9559](https://github.com/adafruit/circuitpython/pull/9559) (Open 709 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10283](https://github.com/adafruit/circuitpython/pull/10283) (Open 467 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10320](https://github.com/adafruit/circuitpython/pull/10320) (Open 451 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10440](https://github.com/adafruit/circuitpython/pull/10440) (Open 405 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10499](https://github.com/adafruit/circuitpython/pull/10499) (Open 379 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10538](https://github.com/adafruit/circuitpython/pull/10538) (Open 366 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10610](https://github.com/adafruit/circuitpython/pull/10610) (Open 333 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10670](https://github.com/adafruit/circuitpython/pull/10670) (Open 291 days)  
+  * [https://github.com/adafruit/circuitpython/pull/10786](https://github.com/adafruit/circuitpython/pull/10786) (Open 187 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/10915](https://github.com/adafruit/circuitpython/pull/10915) (Open 124 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11040](https://github.com/adafruit/circuitpython/pull/11040) (Open 62 days)  
+  * [https://github.com/adafruit/circuitpython/pull/11102](https://github.com/adafruit/circuitpython/pull/11102) (Open 25 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/11131](https://github.com/adafruit/circuitpython/pull/11131) (Open 13 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/11135](https://github.com/adafruit/circuitpython/pull/11135) (Open 11 days) (draft)  
+  * [https://github.com/adafruit/circuitpython/pull/11166](https://github.com/adafruit/circuitpython/pull/11166) (Open 2 days)  
+* 7 closed issues by 2 people, 7 opened by 5 people  
+* 764 open issues  
+  * [https://github.com/adafruit/circuitpython/issues](https://github.com/adafruit/circuitpython/issues)  
+* 8 active milestones  
+* 10.2.x: 0 open issues  
+* 10.3.0: 19 open issues  
+* 10.x.x: 39 open issues  
+* 11.0.0: 14 open issues  
+* Libraries: 12 open issues  
+* Long term: 663 open issues  
+* Support: 7 open issues  
+* Third-party: 11 open issues  
+* 0 issues not assigned a milestone
+
+### 8:10 Libraries
+
+* Adafruit Libraries: 396 Community Libraries: 179 (Total: 575\)  
+* 12 pull requests merged  
+  * 5 authors \- **giri256**, **madmx5**, grgrant, FoamyGuy, **hueyalex**  
+  * 5 reviewers \- dhalbert, tannewt, FoamyGuy, tekktrik, brentru  
+  * Merged pull requests:  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_AdafruitIO/pull/136](https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/pull/136) (Days open: 68\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_INA23x/pull/4](https://github.com/adafruit/Adafruit_CircuitPython_INA23x/pull/4) (Days open: 7\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_LIS331/pull/10](https://github.com/adafruit/Adafruit_CircuitPython_LIS331/pull/10) (Days open: 3\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Register/pull/61](https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/61) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Pixelbuf/pull/15](https://github.com/adafruit/Adafruit_CircuitPython_Pixelbuf/pull/15) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Display\_Text/pull/239](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/pull/239) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Motor/pull/79](https://github.com/adafruit/Adafruit_CircuitPython_Motor/pull/79) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_GPS/pull/127](https://github.com/adafruit/Adafruit_CircuitPython_GPS/pull/127) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_GPS/pull/126](https://github.com/adafruit/Adafruit_CircuitPython_GPS/pull/126) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Display\_Emoji\_Text/pull/7](https://github.com/adafruit/Adafruit_CircuitPython_Display_Emoji_Text/pull/7) (Days open: 1\)  
+    * [https://github.com/adafruit/Adafruit\_CircuitPython\_Bundle/pull/550](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/550) (Days open: 1\)  
+    * [https://github.com/adafruit/CircuitPython\_Community\_Bundle/pull/283](https://github.com/adafruit/CircuitPython_Community_Bundle/pull/283) (Days open: 1\)  
+  * 39 open pull requests (Oldest: 1446, Newest: 1\)  
+* 11 closed issues by 4 people, 3 opened by 2 people  
+  * 777 open issues  
+  * 2 good first issues  
+* [https://circuitpython.org/contributing](https://circuitpython.org/contributing)
+
+#### Library updates in the last seven days:
+
+* **New Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_NAU88L21](https://github.com/adafruit/Adafruit_CircuitPython_NAU88L21)  
+  * [Kinetic-Technologies-Inc/CircuitPython\_KineticRGB](https://github.com/Kinetic-Technologies-Inc/CircuitPython_KineticRGB)  
+* **Updated Libraries**  
+  * [adafruit/Adafruit\_CircuitPython\_Register](https://github.com/adafruit/Adafruit_CircuitPython_Register)  
+  * [adafruit/Adafruit\_CircuitPython\_INA23x](https://github.com/adafruit/Adafruit_CircuitPython_INA23x)  
+  * [adafruit/Adafruit\_CircuitPython\_AdafruitIO](https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO)  
+  * [relic-se/CircuitPython\_TLV320AIC3204](https://github.com/relic-se/CircuitPython_TLV320AIC3204)
+
+### 12:08 Blinka
+
+* 2 pull requests merged  
+  * 2 authors \- giri256, makermelissa  
+  * 2 reviewers \- tannewt, makermelissa  
+* 13 open pull requests  
+  * [https://github.com/adafruit/Adafruit\_Blinka/pull/884](https://github.com/adafruit/Adafruit_Blinka/pull/884) (Open 719 days) (draft)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/79](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/79) (Open 147 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/88](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/88) (Open 29 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/87](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/87) (Open 29 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/28](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/28) (Open 21 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/21](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/21) (Open 20 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/30](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/30) (Open 14 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/89](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/89) (Open 13 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/23](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/23) (Open 13 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/24](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/24) (Open 12 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/pull/31](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/pull/31) (Open 7 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/pull/90](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/pull/90) (Open 6 days)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Neopixel/pull/25](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/pull/25) (Open 6 days)  
+* 3 closed issues by 2 people, 0 opened by 0 people  
+* 78 open issues  
+  * [https://github.com/adafruit/Adafruit\_Blinka/issues](https://github.com/adafruit/Adafruit_Blinka/issues) (34)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Displayio/issues](https://github.com/adafruit/Adafruit_Blinka_Displayio/issues) (9)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_Piomatter/issues](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_Raspberry\_Pi5\_rp1pio/issues](https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_rp1pio/issues) (13)  
+  * [https://github.com/adafruit/Adafruit\_Blinka\_bleio/issues](https://github.com/adafruit/Adafruit_Blinka_bleio/issues) (10)  
+  * [https://github.com/adafruit/Adafruit\_Python\_Extended\_Bus/issues](https://github.com/adafruit/Adafruit_Python_Extended_Bus/issues) (1)  
+  * [https://github.com/adafruit/Adafruit\_Python\_PlatformDetect/issues](https://github.com/adafruit/Adafruit_Python_PlatformDetect/issues) (1)  
+* Number of supported boards: 174
+
+## 13:20 Hug reports
+
+@danh (hosting)
+
+* @grgrant for fixing a number of library bugs
+
+13:56 @foamyguy
+
+* @IonEwe2 (Darth\_Paul) on discord for tip about 1.5v lion AA/ AAAs  
+* @relic-se for looking over I2S duplex functionality and discussions around it  
+* @smitka for venturing into 3D support for picogame
+
+14:43 @tannewt
+
+* Our discord mods and helpers for notifying and deleting crypto image spam.
+
+## 15:16 Status Updates
+
+15:40 @danh (hosting)
+
+* Finished mbedtls update for RP2xxx boards. This fixes a specific user problem but was overdue anyway.  
+* Starting to work on BLE workflow problems.
+
+16:45 @foamyguy
+
+* I2S duplex merged, and NAU88L21 driver library is added to the bundle.   
+* Wrapping up TE EP-2350 ting guide today  
+* Look into USB audio stereo PR, submit Flanger effect PR
+
+17:43 @tannewt
+
+* Placing HIL stuff on the back burner to focus on LM20A on Zephyr polish.  
+* Last week I got the HIL python stack flashing the ESP over USBIP. Will push all of that code this week.  
+* This week is focusing on BLE GATT support in Zephyr for the LM20A.
+
+## 19:15 In The Weeds
+
+@BobG: (GitHub grgrant)  Memory footprint disparity between temperature sensors in part from using adafruit\_register routines vs direct register access.  An open issue for tmp117 motivated the research.  [TMP117\#11](https://github.com/adafruit/Adafruit_CircuitPython_TMP117/issues/11) where Lady Ada had someone looking into a complaint about the library size.
+
+First four libraries do direct register/bit manipulation and the last two use one of two adafruit\_register RO/RWbit(s)/ROUnary library sets
+
+ahtx0     2176  
+stcc4     4144  
+hdc302x   4366  
+scd4x     4704  
+tmp117   13008  
+bmp5xx   14192
+
+Kudos to Scott for I2C and Tim for the newer SPI register accessor version.  It is elegant code that abstracts and makes obvious the various register accesses needed in drivers.  Probably worth the cost memory hit given most MCUs can handle it.
+
+I’ve done quite a bit of instrumentation and it doesn’t appear that tweaks to the libraries or merging will net much savings (maybe 1-2k).
+
+One item perhaps worth discussing is adafruit\_register.i2c\_struct.UnaryStruct allocates a bytearray on every access where register\_struct allocates bytearray in init.  Used for tmp117 temperature read possibly doing heap churn. 
+
+My one remaining item for discussion is whether having the bytearray allocated statically in init or dynamically in get and set each have their respective advantages.  Seldom used register access using dynamic and garbage collected and frequently used registers statically allocated.  Or whether a class wide buffer that is reused would be too dangerous.
+
+## 37:31 Wrap-Up
+
+Next meeting is Monday, August 10, 2026 at 2pm US ET / 11 am US PT.


### PR DESCRIPTION
Added notes from the CircuitPython Weekly Meeting on August 3rd, 2026, including community news, library updates, and status reports.